### PR TITLE
Map "Saint Seiya: Saintia Shou"

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -34599,7 +34599,7 @@
   <anime anidbid="12647" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt6335734">
     <name>Yoru wa Mijikashi Aruke yo Otome</name>
   </anime>
-  <anime anidbid="12648" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="12648" tvdbid="72775" defaulttvdbseason="12" episodeoffset="" tmdbid="" imdbid="">
     <name>Saint Seiya: Saintia Shou</name>
   </anime>
   <anime anidbid="12649" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt6336356">


### PR DESCRIPTION
As much as I disagree with TheTVDB's stance on this spin-off being merged to the parent show as a season, it is what it is and they won't change that back.

AniDB: Saint Seiya: Saintia Shou ([12648](https://anidb.net/anime/12648))
TheTVDB: Saint Seiya ([72775](https://www.thetvdb.com/dereferrer/series/72775)) - [Season 12](https://www.thetvdb.com/series/saint-seiya/seasons/official/12)