### PR TITLE
Fixed Shingeki no Kyojin OAD matching

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -27138,7 +27138,7 @@
   <anime anidbid="9826" tvdbid="267440" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
     <name>Shingeki no Kyojin OAD</name>
     <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-2;2-12;3-13;4-16;5-17;6-20;7-21;8-22;</mapping>
+      <mapping anidbseason="1" tvdbseason="0">;1-7;2-12;3-13;4-15;5-17;6-20;7-22;8-23;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="9828" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
Episode numbering for Shingeki no Kyojin OAD was out due to additional titles being added to TheTVDB Specials.