### PR TITLE
Fix Tensei Shitara Slime Datta Ken (2021 Dai 2 Bu)

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -42504,7 +42504,7 @@
   <anime anidbid="15455" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>100 Nichikan Ikita Wani</name>
   </anime>
-  <anime anidbid="15456" tvdbid="352408" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15456" tvdbid="352408" defaulttvdbseason="2" episodeoffset="12" tmdbid="" imdbid="">
     <name>Tensei Shitara Slime Datta Ken (2021 Dai 2 Bu)</name>
   </anime>
   <anime anidbid="15457" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
remap season 2 part 2 of *Tensei Shitara Slime Datta Ken* so it doesn't override the base show.