### PR TITLE
Changing the Order for the TVDB Air Specials

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -5856,7 +5856,7 @@
   <anime anidbid="1667" tvdbid="79101" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0807703">
     <name>Gekijouban Air</name>
     <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-1;2-1;3-1;4-1;5-1;6-1;</mapping>
+      <mapping anidbseason="1" tvdbseason="0">;1-1;2-0;3-0;4-0;5-0;6-0;</mapping>
     </mapping-list>
     <supplemental-info>
       <studio>Toei Animation</studio>

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -5856,7 +5856,7 @@
   <anime anidbid="1667" tvdbid="79101" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0807703">
     <name>Gekijouban Air</name>
     <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-3;2-3;3-3;4-3;5-3;6-3;</mapping>
+      <mapping anidbseason="1" tvdbseason="0">;1-1;2-1;3-1;4-1;5-1;6-1;</mapping>
     </mapping-list>
     <supplemental-info>
       <studio>Toei Animation</studio>
@@ -6813,6 +6813,9 @@
   </anime>
   <anime anidbid="2002" tvdbid="79101" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Air</name>
+	<mapping-list>
+      <mapping anidbseason="0" tvdbseason="0">;1-2;2-3;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="2003" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Onna Kyoushi Nijuusan-sai</name>


### PR DESCRIPTION
The Movie was displaying with the eps 2 special title, and the Eps 1 special had the movie title. It seems the tvdb specials order moved the movie from the 3rd spot to the first.

Air specials tvdb
https://www.thetvdb.com/series/air/seasons/official/0

Air Movie anidb
https://anidb.net/anime/1667

Air Tv show anidb
https://anidb.net/anime/2002