### PR TITLE
TVDB Changed order so Hell's Kitchen is now eps 3 instead of 4

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -17818,7 +17818,7 @@
   <anime anidbid="6564" tvdbid="150471" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Angel Beats!</name>
     <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0">;1-2;2-1;3-4;4-0;5-5;6-0;7-0;8-0;9-3;</mapping>
+      <mapping anidbseason="0" tvdbseason="0">;1-2;2-1;3-3;4-0;5-0;6-0;7-0;8-0;9-4;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="6566" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt1496690">


### PR DESCRIPTION
TV DB changed Hell's Kitchen to eps 3, the same as Anidb, and moved the Afterlife Battlefront Skit Collection to eps 4. Additionally I only see 4 specials on TVDb so I changed the Anidb mapping of 5 to 0.

Angel Beats Anidb 6564
https://anidb.net/anime/6564

Angel Beats TVDb 150471
https://www.thetvdb.com/series/angel-beats/seasons/official/0