### PR TITLE
Chobits Recap Episodes

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -53,6 +53,12 @@
   </anime>
   <anime anidbid="12" tvdbid="72070" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Chobits</name>
+	<mapping-list>
+	  <mapping anidbseason="0" tvdbseason="0">;1-3;2-4;</mapping>
+	  <mapping anidbseason="1" tvdbseason="1" start="10" end="17" offset="-1"/>
+	  <mapping anidbseason="1" tvdbseason="1" start="18" end="26" offset="-2"/>
+	  <mapping anidbseason="1" tvdbseason="0">;9-1;10-2;</mapping>
+	</mapping-list>
   </anime>
   <anime anidbid="13" tvdbid="78947" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Noir</name>

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -56,8 +56,8 @@
 	<mapping-list>
 	  <mapping anidbseason="0" tvdbseason="0">;1-3;2-4;</mapping>
 	  <mapping anidbseason="1" tvdbseason="1" start="10" end="17" offset="-1"/>
-	  <mapping anidbseason="1" tvdbseason="1" start="18" end="26" offset="-2"/>
-	  <mapping anidbseason="1" tvdbseason="0">;9-1;10-2;</mapping>
+	  <mapping anidbseason="1" tvdbseason="1" start="19" end="26" offset="-2"/>
+	  <mapping anidbseason="1" tvdbseason="0">;9-1;18-2;</mapping>
 	</mapping-list>
   </anime>
   <anime anidbid="13" tvdbid="78947" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
Anidb includes 2 of the recap episodes as regular episodes 9 and 18. While they are listed as Special episodes 1 and 2 on tvdb

I don't know if this is the preferred way to map it but it accomplished what I needed when I was testing locally.

Chobits: Anidb https://anidb.net/anime/12

Chobits Specials TvDB https://www.thetvdb.com/series/chobits/seasons/official/0
Chobits Tvdb https://www.thetvdb.com/series/chobits/seasons/official/1

So AniDB eps 9 (Shinbo and Sumomo Chat) is equivalent to the TVDB Special Episode 1
AniDB eps 18 (Minoru and Yuzuki Chat) is TVDB Special Episode 2
AniDB Special Eps 1 (Hibiya and Kotoko Chat) is TVDB Special Episode 3
Anidb Special Eps 2 (Chibits: Sumomo and Kotoko Deliver) is TVDB Special Episode 4