### PR TITLE
Cowboy Bebop Movie changed offset on TVDB

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -992,7 +992,7 @@
     <name>Cowboy Bebop: Tengoku no Tobira</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;2-0;3-0;4-0;</mapping>
-      <mapping anidbseason="1" tvdbseason="0">;1-1;2-1;3-1;4-1;5-1;6-1;</mapping>
+      <mapping anidbseason="1" tvdbseason="0">;1-3;2-3;3-3;4-3;5-3;6-3;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="220" tvdbid="tv special" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -992,7 +992,7 @@
     <name>Cowboy Bebop: Tengoku no Tobira</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;2-0;3-0;4-0;</mapping>
-      <mapping anidbseason="1" tvdbseason="0">;1-3;2-3;3-3;4-3;5-3;6-3;</mapping>
+      <mapping anidbseason="1" tvdbseason="0">;1-3;2-0;3-0;4-0;5-0;6-0;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="220" tvdbid="tv special" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
Cowboy Bebop Movie (https://anidb.net/anime/219) was moved on TVDB from Special 01 to 03 (https://thetvdb.com/series/cowboy-bebop/episodes/360926)
I'm guessing because "Airing Order", it was kept as 01 on [DVD order](https://thetvdb.com/series/cowboy-bebop/seasons/dvd/0) but nothing uses that