### PR TITLE
Map Seasons for Fairy Tail sequels

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -27575,8 +27575,13 @@
   <anime anidbid="9979" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Koroshiya-san: The Hired Gun</name>
   </anime>
-  <anime anidbid="9980" tvdbid="114801" defaulttvdbseason="5" episodeoffset="175" tmdbid="" imdbid="">
+  <anime anidbid="9980" tvdbid="114801" defaulttvdbseason="a" episodeoffset="175" tmdbid="" imdbid="">
     <name>Fairy Tail (2014)</name>
+    <mapping-list>
+      <mapping anidbseason="1" tvdbseason="5" start="1" end="51" offset="0"/>
+      <mapping anidbseason="1" tvdbseason="6" start="52" end="90" offset="-51"/>
+      <mapping anidbseason="1" tvdbseason="7" start="91" end="102" offset="-90"/>
+    </mapping-list>
   </anime>
   <anime anidbid="9982" tvdbid="79685" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">
     <name>Hajime no Ippo: The Fighting! - Rising</name>
@@ -36431,8 +36436,11 @@
   <anime anidbid="13294" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Onyankopon</name>
   </anime>
-  <anime anidbid="13295" tvdbid="114801" defaulttvdbseason="8" episodeoffset="277" tmdbid="" imdbid="">
+  <anime anidbid="13295" tvdbid="114801" defaulttvdbseason="a" episodeoffset="277" tmdbid="" imdbid="">
     <name>Fairy Tail (2018)</name>
+    <mapping-list>
+      <mapping anidbseason="1" tvdbseason="8" start="1" end="51" offset="0"/>
+    </mapping-list>
   </anime>
   <anime anidbid="13296" tvdbid="346948" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Harukana Receive</name>


### PR DESCRIPTION
#11 caused Fairy Tail's sequels from 2014 and 2018 to stack up on Season 5 and 8 respectively, while adding the episode offset.
So Fairy Tail (2014) episodes were showing up as `s05e176`-`s05e277`, and Fairy Tail (2018) would show up as `s08e278`-`s08e339`, leaving seasons 6 and 7 empty\nonexistent and 5 and 8 without any metadata since episodes 1-51 also weren't present.