### PR TITLE
Fix #121

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -40591,7 +40591,7 @@
   <anime anidbid="14750" tvdbid="369395" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Choujin Koukousei-tachi wa Isekai demo Yoyuu de Ikinuku You Desu!</name>
   </anime>
-  <anime anidbid="14751" tvdbid="361754" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="88064">
+  <anime anidbid="14751" tvdbid="361754" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Try Knights</name>
   </anime>
   <anime anidbid="14752" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -40855,7 +40855,7 @@
   <anime anidbid="14839" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Baja no Studio: Baja no Mita Umi</name>
   </anime>
-  <anime anidbid="14840" tvdbid="330139" defaulttvdbseason="0" episodeoffset="1" tmdbid="610892" imdbid="610892">
+  <anime anidbid="14840" tvdbid="330139" defaulttvdbseason="0" episodeoffset="1" tmdbid="610892" imdbid="tt10477558">
     <name>Violet Evergarden Gaiden: Eien to Jidou Shuki Ningyou</name>
   </anime>
   <anime anidbid="14843" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
Fix IMDB ID for Violet Evergarden Movie\Special
Remove TMDB ID (wrongly placed at `imdbid` parameter) for Try Knights because it's a series and #342

Closes #121 