### PR TITLE
Fix rearranged Maidragon specials

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -33151,7 +33151,7 @@
   <anime anidbid="12091" tvdbid="318893" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Kobayashi-san Chi no Maidragon</name>
     <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0">;1-8;2-1;3-2;4-3;5-4;6-5;7-6;8-7;</mapping>
+      <mapping anidbseason="0" tvdbseason="0" offset="1">;1-1;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="12092" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -40378,7 +40378,7 @@
   <anime anidbid="14678" tvdbid="318893" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Kobayashi-san Chi no Maidragon S</name>
     <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0" start="1" end="22" offset="7">;1-30;</mapping>
+      <mapping anidbseason="0" tvdbseason="0" start="1" end="22" offset="8">;1-2;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="14679" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="594188" imdbid="tt9760504">


### PR DESCRIPTION
It seems the hopes expressed in issue #95 did not come true: The
full-length BD episode was added to TheTVDB as S00E02, shifting around
specials for both seasons. This commit fixes mappings for both seasons.

- Season 1 - https://anidb.net/anime/12091
- Season 2 - https://anidb.net/anime/14678
- TheTVDB - https://www.thetvdb.com/series/miss-kobayashis-dragon-maid/seasons/official/0

First PR, please let me know if my syntax is off.