### PR TITLE
Kishibe Rohan wa Ugokanai: fix mapping

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -37915,6 +37915,7 @@
     <name>Kishibe Rohan wa Ugokanai</name>
     <mapping-list>
       <mapping anidbseason="1" tvdbseason="0">;1-1;2-2;3-6;4-7;</mapping>
+      <mapping anidbseason="99" tvdbseason="1" start="1" end="4"></mapping>
     </mapping-list>
   </anime>
   <anime anidbid="13813" tvdbid="344200" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
Kishibe Rohan wa Ugokanai maps to the tvdb entry for the entire JoJo (2012) series, under [Specials](https://thetvdb.com/series/jojos-bizarre-adventure-2012/seasons/official/0).

Before this commit, Kishibe Rohan S01E01 maps to tvdb-S00E01 ([Millionaire Village](https://thetvdb.com/series/jojos-bizarre-adventure-2012/episodes/6446443)), but also tvdb-S01E01 ([Dio the Invader](https://thetvdb.com/series/jojos-bizarre-adventure-2012/episodes/4410841)). Agents might unfortunately pick the latter for metadata. This commit "clears out space" in S01 by mapping the first four episodes to Season 99.

I've tested this and it works. Is there a cleaner method?