### PR TITLE
Fix Chaika OVA Title

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -29230,7 +29230,7 @@
   <anime anidbid="10648" tvdbid="278127" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
     <name>Hitsugi no Chaika: Nerawareta Hitsugi / Yomigaeru Iseki</name>
     <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-1+2;</mapping>
+      <mapping anidbseason="1" tvdbseason="0"/>
     </mapping-list>
   </anime>
   <anime anidbid="10649" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
OVA title was coming up with the episode 1 title. Removed the specific episode mapping gives it the OVA title

1. Chaika: The Coffin Princess - The Targeted Coffin / Ruins Resurrected
   - https://anidb.net/anime/10648
   - https://thetvdb.com/series/chaika-the-coffin-princess/seasons/official/0