### PR TITLE
Love Hina Specials shuffled around on tvdb

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -179,7 +179,7 @@
   <anime anidbid="35" tvdbid="70861" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Love Hina</name>
     <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0">;1-8;2-0;3-4;4-0;5-3;6-0;7-0;</mapping>
+      <mapping anidbseason="0" tvdbseason="0">;1-8;2-0;3-7;4-0;5-6;6-0;7-0;</mapping>
     </mapping-list>
     <supplemental-info>
       <studio>XEBEC</studio>
@@ -239,7 +239,7 @@
   <anime anidbid="48" tvdbid="79445" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Ippatsu Kikimusume</name>
   </anime>
-  <anime anidbid="49" tvdbid="70861" defaulttvdbseason="0" episodeoffset="4" tmdbid="" imdbid="">
+  <anime anidbid="49" tvdbid="70861" defaulttvdbseason="0" episodeoffset="2" tmdbid="" imdbid="">
     <name>Love Hina Again</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;</mapping>


### PR DESCRIPTION
The Love Hina specials got shuffled around tvdb. It effects the specials of the main series and Love Hina Again

1. Season 1 - Love Hina - Final Selection is now eps 6 on tvdb. and the Osaka Live event 7
  - https://anidb.net/anime/35
  - https://thetvdb.com/series/love-hina/seasons/official/0

2. Season 0 - Love Hina Again - Shifted to eps 3, 4, 5 on tvdb special instead of 5, 6, 7
  - https://anidb.net/anime/49
  - https://thetvdb.com/series/love-hina/seasons/official/0