### PR TITLE
Some Fall 2022 shows

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -45470,7 +45470,7 @@
   <anime anidbid="16572" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Akai Hoshi Aoi Hoshi: Tenmon Carat no Hoshi kara</name>
   </anime>
-  <anime anidbid="16573" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="16573" tvdbid="375271" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Fumetsu no Anata e Season 2</name>
   </anime>
   <anime anidbid="16574" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -47024,7 +47024,7 @@
   <anime anidbid="17123" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Akachan Honbuchou (2022)</name>
   </anime>
-  <anime anidbid="17125" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17125" tvdbid="376751" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">
     <name>Xian Wang de Richang Shenghuo (2022)</name>
   </anime>
   <anime anidbid="17126" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
Mapped second season of "Fumetsu no Anata e" and third season of "Xian Wang de Richang Shenghuo"

Season 2 - Fumetsu no Anata e
    - https://anidb.net/anime/16573
    - https://thetvdb.com/index.php?tab=series&id=375271

Season 3 - Xian Wang de Richang Shenghuo
    - https://anidb.net/anime/17125
    - https://thetvdb.com/index.php?tab=series&id=376751
