### PR TITLE
Update mapping for Assault Lily: Fruits

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -43958,7 +43958,7 @@
   <anime anidbid="15981" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Puchimiku D4DJ Petit Mix</name>
   </anime>
-  <anime anidbid="15982" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15982" tvdbid="408477" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Assault Lily: Fruits</name>
   </anime>
   <anime anidbid="15983" tvdbid="395400" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -29114,6 +29114,9 @@
   </anime>
   <anime anidbid="10603" tvdbid="269872" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Hello!! Kin'iro Mosaic</name>
+    <mapping-list>
+      <mapping anidbseason="0" tvdbseason="0">;1-0;2-0;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="10605" tvdbid="web" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Tuzki: Love Assassin</name>
@@ -32996,8 +32999,11 @@
   <anime anidbid="12036" tvdbid="267437" defaulttvdbseason="0" episodeoffset="6" tmdbid="" imdbid="">
     <name>Yuyushiki: Komarasetari, Komarasaretari</name>
   </anime>
-  <anime anidbid="12037" tvdbid="269872" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt5988680">
+  <anime anidbid="12037" tvdbid="269872" defaulttvdbseason="0" episodeoffset="" tmdbid="445475" imdbid="tt5988680">
     <name>Kin'iro Mosaic: Pretty Days</name>
+    <mapping-list>
+      <mapping anidbseason="0" tvdbseason="0">;1-0;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="12038" tvdbid="312559" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
     <name>Drifters: Special Edition</name>
@@ -42480,8 +42486,11 @@
   <anime anidbid="15449" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Bleach: Sennen Kessen Hen</name>
   </anime>
-  <anime anidbid="15450" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15450" tvdbid="269872" defaulttvdbseason="0" episodeoffset="1" tmdbid="693853" imdbid="">
     <name>Gekijouban Kin'iro Mosaic: Thank You!!</name>
+    <mapping-list>
+      <mapping anidbseason="0" tvdbseason="0">;1-0;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="15451" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Micchiri Wanko! Animation</name>


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/15982 | https://thetvdb.com/index.php?tab=series&id=408477 | Season 01 tvdb mapping |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->