### PR TITLE
TVDB update mapping Gate Keepers 21

### DIFF
--- a/anime-list-full.xml
+++ b/anime-list-full.xml
@@ -34781,7 +34781,7 @@
   <anime anidbid="16296" tvdbid="294002" defaulttvdbseason="4">
     <name>Overlord IV</name>
     <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0" start="1" end="13" offset="44"/>
+      <mapping anidbseason="0" tvdbseason="0" start="1" end="12" offset="44"/>
     </mapping-list>
   </anime>
   <anime anidbid="16300" tvdbid="402412" defaulttvdbseason="1">

--- a/anime-list-full.xml
+++ b/anime-list-full.xml
@@ -34781,7 +34781,7 @@
   <anime anidbid="16296" tvdbid="294002" defaulttvdbseason="4">
     <name>Overlord IV</name>
     <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0" start="1" end="12" offset="44"/>
+      <mapping anidbseason="0" tvdbseason="0" start="1" end="13" offset="44"/>
     </mapping-list>
   </anime>
   <anime anidbid="16300" tvdbid="402412" defaulttvdbseason="1">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -46724,7 +46724,7 @@
   <anime anidbid="17022" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Gudetama Freestyle</name>
   </anime>
-  <anime anidbid="17023" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17023" tvdbid="338455" defaulttvdbseason="4" episodeoffset="" tmdbid="" imdbid="">
     <name>Golden Kamuy (2022)</name>
   </anime>
   <anime anidbid="17024" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -46892,7 +46892,7 @@
   <anime anidbid="17078" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Saihate no Paladin 2</name>
   </anime>
-  <anime anidbid="17079" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17079" tvdbid="339278" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Pop Team Epic (2022)</name>
   </anime>
   <anime anidbid="17080" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -46492,7 +46492,7 @@
   <anime anidbid="16930" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Kaoru no Taisetsu na Mono</name>
   </anime>
-  <anime anidbid="16931" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="16931" tvdbid="411800" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Arknights: Prelude to Dawn</name>
   </anime>
   <anime anidbid="16933" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -47108,7 +47108,7 @@
   <anime anidbid="17156" tvdbid="415280" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Prima Doll</name>
   </anime>
-  <anime anidbid="17157" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17157" tvdbid="415310" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Mushikaburi Hime</name>
   </anime>
   <anime anidbid="17159" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -48011,7 +48011,7 @@
   <anime anidbid="17474" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Kin no Kuni Mizu no Kuni</name>
   </anime>
-  <anime anidbid="17475" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17475" tvdbid="421676" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Akiba Maid Sensou</name>
   </anime>
   <anime anidbid="17476" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -1106,7 +1106,7 @@
       <mapping anidbseason="0" tvdbseason="0" start="2" end="27" offset="5">;1-0;28-0;29-0;30-0;31-0;32-0;33-0;34-0;35-0;36-0;37-0;38-0;39-0;40-0;41-0;42-0;43-0;44-0;45-0;46-0;47-0;48-0;49-0;50-0;51-0;52-0;53-0;54-0;55-0;56-0;57-0;58-0;59-0;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="248" tvdbid="78917" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="248" tvdbid="78918" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Gate Keepers 21</name>
     <supplemental-info>
       <studio>Gonzo Digimation</studio>

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -47605,7 +47605,7 @@
   <anime anidbid="17329" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Eiga Kaiketsu Zorori: Lalala Star Tanjou</name>
   </anime>
-  <anime anidbid="17330" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17330" tvdbid="419283" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Cool Doji Danshi</name>
   </anime>
   <anime anidbid="17331" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -44491,6 +44491,9 @@
   </anime>
   <anime anidbid="16172" tvdbid="378609" defaulttvdbseason="1" episodeoffset="11" tmdbid="" imdbid="">
     <name>86 (2021)</name>
+    <mapping-list>
+      <mapping anidbseason="0" tvdbseason="0" start="1" end="3" offset="1"/>
+    </mapping-list>
   </anime>
   <anime anidbid="16173" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Gekijouban Uta no Prince-sama: Maji Love Starish Tours</name>

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -46874,7 +46874,7 @@
   <anime anidbid="17072" tvdbid="402412" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Komi-san wa, Komyushou Desu. (2022)</name>
   </anime>
-  <anime anidbid="17073" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17073" tvdbid="402231" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Muv-Luv Alternative (2022)</name>
   </anime>
   <anime anidbid="17074" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -45838,7 +45838,7 @@
   <anime anidbid="16699" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Da Shi Jie</name>
   </anime>
-  <anime anidbid="16700" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="16700" tvdbid="418364" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Kidou Senshi Gundam: Suisei no Majo</name>
   </anime>
   <anime anidbid="16701" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -44042,7 +44042,7 @@
   <anime anidbid="16009" tvdbid="325374" defaulttvdbseason="5" episodeoffset="" tmdbid="" imdbid="">
     <name>Duel Masters King!</name>
   </anime>
-  <anime anidbid="16010" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="16010" tvdbid="337336" defaulttvdbseason="3" episodeoffset="13" tmdbid="" imdbid="">
     <name>Idolish Seven: Third Beat! (2022)</name>
   </anime>
   <anime anidbid="16011" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -44528,7 +44528,7 @@
   <anime anidbid="16184" tvdbid="401906" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Gyakuten Sekai no Denchi Shoujo</name>
   </anime>
-  <anime anidbid="16185" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="16185" tvdbid="402180" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Obey Me!</name>
   </anime>
   <anime anidbid="16186" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -47942,7 +47942,7 @@
   <anime anidbid="17449" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Oshi no Ko</name>
   </anime>
-  <anime anidbid="17450" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17450" tvdbid="402180" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Obey Me! (2022)</name>
   </anime>
   <anime anidbid="17451" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -304,7 +304,7 @@
       <mapping anidbseason="1" tvdbseason="0">;1-1;2-1;3-1;4-1;5-1;6-1;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="62" tvdbid="81694" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="62" tvdbid="81694" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Mata Mata Saber Marionette J</name>
     <supplemental-info replace="true">
       <studio>Hal Film Maker</studio>
@@ -1689,10 +1689,10 @@
   <anime anidbid="393" tvdbid="205521" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Makai Tenshou</name>
   </anime>
-  <anime anidbid="394" tvdbid="81694" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="394" tvdbid="81694" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">
     <name>Saber Marionette J to X</name>
     <mapping-list>
-      <mapping anidbseason="0" tvdbseason="2">;1-26;</mapping>
+      <mapping anidbseason="0" tvdbseason="3">;1-26;</mapping>
     </mapping-list>
     <before>;1-26;</before>
   </anime>

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -47921,10 +47921,10 @@
   <anime anidbid="17442" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Douluo Dalu: Feng Huo Bu Xi</name>
   </anime>
-  <anime anidbid="17443" tvdbid="421092" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17443" tvdbid="420982" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Sekai no Owari ni Shiba Inu to</name>
   </anime>
-  <anime anidbid="17444" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17444" tvdbid="421092" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Yuusha Party o Tsuihou Sareta Beast Tamer, Saikyoushu no Nekomimi Shoujo to Deau</name>
   </anime>
   <anime anidbid="17445" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -40164,8 +40164,8 @@
     <name>Shaonu Qianxian: Renxing Xiao Juchang</name>
     <mapping-list>
       <mapping anidbseason="1" tvdbseason="1" start="1" end="12"/>
-	  <mapping anidbseason="1" tvdbseason="2" start="13" end="24" offset="-12"/>
-    </mapping-list>	
+      <mapping anidbseason="1" tvdbseason="2" start="13" end="24" offset="-12"/>
+    </mapping-list>
   </anime>
   <anime anidbid="14599" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Gaki ni Modotte Yarinaoshi!!!</name>

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -38702,7 +38702,7 @@
   <anime anidbid="14090" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>To the Moon</name>
   </anime>
-  <anime anidbid="14091" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14091" tvdbid="413555" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Chikyuugai Shounen Shoujo</name>
   </anime>
   <anime anidbid="14092" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -43028,7 +43028,7 @@
   <anime anidbid="15643" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Blue: Line Step Brush</name>
   </anime>
-  <anime anidbid="15644" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15644" tvdbid="388248" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Chuan Shu Zijiu Zhinan</name>
   </anime>
   <anime anidbid="15645" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -3718,7 +3718,7 @@
   <anime anidbid="965" tvdbid="223491" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Machine Robo: Chronos no Dai Gyakushuu</name>
   </anime>
-  <anime anidbid="966" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="966" tvdbid="385008" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Hareluya II Boy</name>
   </anime>
   <anime anidbid="967" tvdbid="251752" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -45352,7 +45352,7 @@
   <anime anidbid="16523" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Baolie Feiche 3: Shou Shen Heti</name>
   </anime>
-  <anime anidbid="16525" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="16525" tvdbid="418740" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Hanabi-chan wa Okure-gachi</name>
   </anime>
   <anime anidbid="16527" tvdbid="408348" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -47041,7 +47041,7 @@
   <anime anidbid="17126" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Wan Yu Feng Shen</name>
   </anime>
-  <anime anidbid="17127" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17127" tvdbid="418499" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Jantama Pong</name>
   </anime>
   <anime anidbid="17128" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -11562,7 +11562,7 @@
   <anime anidbid="3702" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Inko</name>
   </anime>
-  <anime anidbid="3703" tvdbid="81932" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="3703" tvdbid="75205" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Bouken Ou Beet Excellion</name>
   </anime>
   <anime anidbid="3704" tvdbid="100161" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -30415,7 +30415,7 @@
   <anime anidbid="11085" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Etsuraku no Tane</name>
   </anime>
-  <anime anidbid="11086" tvdbid="OVA" defaulttvdbseason="1" episodeoffset="" tmdbid="358813" imdbid="">
+  <anime anidbid="11086" tvdbid="305073" defaulttvdbseason="0" episodeoffset="" tmdbid="358813" imdbid="">
     <name>Big Order</name>
   </anime>
   <anime anidbid="11088" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -37605,7 +37605,7 @@
   <anime anidbid="13705" tvdbid="340138" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Emiya-san Chi no Kyou no Gohan</name>
   </anime>
-  <anime anidbid="13706" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="13706" tvdbid="344194" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Binan Koukou Chikyuu Bouei Bu Happy Kiss!</name>
   </anime>
   <anime anidbid="13707" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -42344,7 +42344,7 @@
   <anime anidbid="15389" tvdbid="397250" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Mars Red</name>
   </anime>
-  <anime anidbid="15390" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15390" tvdbid="379918" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Bessatsu Olympia Kyklos</name>
   </anime>
   <anime anidbid="15391" tvdbid="376729" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -43308,7 +43308,7 @@
   <anime anidbid="15743" tvdbid="380654" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Kanojo, Okarishimasu (2022)</name>
   </anime>
-  <anime anidbid="15744" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15744" tvdbid="389200" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Biohazard: Infinite Darkness</name>
   </anime>
   <anime anidbid="15745" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -23772,11 +23772,8 @@
   <anime anidbid="8596" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="unknown">
     <name>Pop</name>
   </anime>
-  <anime anidbid="8597" tvdbid="247691" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="8597" tvdbid="247691" defaulttvdbseason="0" episodeoffset="11" tmdbid="" imdbid="">
     <name>A Channel +Smile</name>
-    <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-12;2-13;3-14;</mapping>
-    </mapping-list>
   </anime>
   <anime anidbid="8599" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt1583243">
     <name>Ecophan</name>
@@ -31760,7 +31757,7 @@
   <anime anidbid="11572" tvdbid="316815" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Mahou Shoujo Ikusei Keikaku</name>
   </anime>
-  <anime anidbid="11573" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="11573" tvdbid="301830" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Brave Beats</name>
   </anime>
   <anime anidbid="11575" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -33048,7 +33045,7 @@
   <anime anidbid="12051" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Uchuu Senkan Yamato 2202: Ai no Senshi-tachi</name>
   </anime>
-  <anime anidbid="12053" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="12053" tvdbid="313185" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Brotherhood: Final Fantasy XV</name>
   </anime>
   <anime anidbid="12054" tvdbid="movie" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="tt5595168">
@@ -37605,7 +37602,7 @@
   <anime anidbid="13705" tvdbid="340138" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Emiya-san Chi no Kyou no Gohan</name>
   </anime>
-  <anime anidbid="13706" tvdbid="344194" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="13706" tvdbid="344194" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Binan Koukou Chikyuu Bouei Bu Happy Kiss!</name>
   </anime>
   <anime anidbid="13707" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -42161,7 +42158,7 @@
   <anime anidbid="15327" tvdbid="392491" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Azur Lane: Bisoku Zenshin!</name>
   </anime>
-  <anime anidbid="15328" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15328" tvdbid="378034" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Bungou to Alchemist: Shinpan no Haguruma</name>
   </anime>
   <anime anidbid="15329" tvdbid="368862" defaulttvdbseason="0" episodeoffset="1" tmdbid="" imdbid="">
@@ -42344,7 +42341,7 @@
   <anime anidbid="15389" tvdbid="397250" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Mars Red</name>
   </anime>
-  <anime anidbid="15390" tvdbid="379918" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15390" tvdbid="379918" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Bessatsu Olympia Kyklos</name>
   </anime>
   <anime anidbid="15391" tvdbid="376729" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -43308,7 +43305,7 @@
   <anime anidbid="15743" tvdbid="380654" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Kanojo, Okarishimasu (2022)</name>
   </anime>
-  <anime anidbid="15744" tvdbid="389200" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15744" tvdbid="389200" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Biohazard: Infinite Darkness</name>
   </anime>
   <anime anidbid="15745" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -45315,7 +45312,7 @@
   <anime anidbid="16510" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Kaijuu Step SDGs Daisakusen</name>
   </anime>
-  <anime anidbid="16511" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="16511" tvdbid="408325" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Can Ci Pin: Fangzhu Xingkong</name>
   </anime>
   <anime anidbid="16512" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -36180,7 +36180,7 @@
   <anime anidbid="13205" tvdbid="264523" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">
     <name>Yama no Susume: Third Season</name>
   </anime>
-  <anime anidbid="13206" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="13206" tvdbid="264523" defaulttvdbseason="0" episodeoffset="3" tmdbid="" imdbid="">
     <name>Yama no Susume: Omoide Present - Natsu: Kokona no 8/31 / Aki: Hinata no 10/28</name>
   </anime>
   <anime anidbid="13207" tvdbid="289884" defaulttvdbseason="0" episodeoffset="18" tmdbid="" imdbid="tt7089882">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -23775,7 +23775,7 @@
   <anime anidbid="8597" tvdbid="247691" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
     <name>A Channel +Smile</name>
     <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-12;2-13;</mapping>
+      <mapping anidbseason="1" tvdbseason="0">;1-12;2-13;3-14;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="8599" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt1583243">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -44402,7 +44402,7 @@
   <anime anidbid="16137" tvdbid="385002" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Higurashi no Naku Koro ni Sotsu</name>
   </anime>
-  <anime anidbid="16138" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="16138" tvdbid="264523" defaulttvdbseason="4" episodeoffset="" tmdbid="" imdbid="">
     <name>Yama no Susume: Next Summit</name>
   </anime>
   <anime anidbid="16140" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -31757,7 +31757,7 @@
   <anime anidbid="11572" tvdbid="316815" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Mahou Shoujo Ikusei Keikaku</name>
   </anime>
-  <anime anidbid="11573" tvdbid="301830" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="11573" tvdbid="301830" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Brave Beats</name>
   </anime>
   <anime anidbid="11575" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -33045,7 +33045,7 @@
   <anime anidbid="12051" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Uchuu Senkan Yamato 2202: Ai no Senshi-tachi</name>
   </anime>
-  <anime anidbid="12053" tvdbid="313185" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="12053" tvdbid="313185" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Brotherhood: Final Fantasy XV</name>
   </anime>
   <anime anidbid="12054" tvdbid="movie" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="tt5595168">
@@ -42158,7 +42158,7 @@
   <anime anidbid="15327" tvdbid="392491" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Azur Lane: Bisoku Zenshin!</name>
   </anime>
-  <anime anidbid="15328" tvdbid="378034" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15328" tvdbid="378034" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Bungou to Alchemist: Shinpan no Haguruma</name>
   </anime>
   <anime anidbid="15329" tvdbid="368862" defaulttvdbseason="0" episodeoffset="1" tmdbid="" imdbid="">
@@ -45312,7 +45312,7 @@
   <anime anidbid="16510" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Kaijuu Step SDGs Daisakusen</name>
   </anime>
-  <anime anidbid="16511" tvdbid="408325" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="16511" tvdbid="408325" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Can Ci Pin: Fangzhu Xingkong</name>
   </anime>
   <anime anidbid="16512" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -35799,7 +35799,7 @@
   <anime anidbid="13069" tvdbid="314284" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Classicaloid (2017)</name>
   </anime>
-  <anime anidbid="13070" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="13070" tvdbid="291724" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Musashino!</name>
   </anime>
   <anime anidbid="13071" tvdbid="283243" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
@@ -42582,7 +42582,7 @@
   <anime anidbid="15475" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Ansatsu Kyoushitsu: Second Season - Kagaijugyou Hen</name>
   </anime>
-  <anime anidbid="15476" tvdbid="394118" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15476" tvdbid="397425" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Maiko-san Chi no Makanai-san</name>
   </anime>
   <anime anidbid="15477" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -43957,7 +43957,7 @@
   <anime anidbid="15979" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Shenshi Mowang: Gentleman Devil</name>
   </anime>
-  <anime anidbid="15980" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15980" tvdbid="409307" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Saiyuuki Reload Zeroin</name>
   </anime>
   <anime anidbid="15981" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -46936,7 +46936,7 @@
   <anime anidbid="17090" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>The Missing 8</name>
   </anime>
-  <anime anidbid="17091" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17091" tvdbid="402227" defaulttvdbseason="1" episodeoffset="13" tmdbid="" imdbid="">
     <name>Kyoukai Senki (2022)</name>
   </anime>
   <anime anidbid="17092" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -14754,7 +14754,7 @@
       <mapping anidbseason="1" tvdbseason="0">;1-4;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="5115" tvdbid="79839" defaulttvdbseason="0" episodeoffset="2" tmdbid="" imdbid="">
+  <anime anidbid="5115" tvdbid="79839" defaulttvdbseason="0" episodeoffset="1" tmdbid="" imdbid="">
     <name>Aria the OVA: Arietta</name>
   </anime>
   <anime anidbid="5116" tvdbid="80330" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -43914,10 +43914,10 @@
   <anime anidbid="15965" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Hologram Circus</name>
   </anime>
-  <anime anidbid="15966" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15966" tvdbid="381536" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Bai Yao Pu Di Yi Ce</name>
   </anime>
-  <anime anidbid="15967" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15967" tvdbid="381536" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Bai Yao Pu Di Er Ji</name>
   </anime>
   <anime anidbid="15968" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -48177,7 +48177,7 @@
   <anime anidbid="17534" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Shen Lan Qi Yu Wushuang Zhu</name>
   </anime>
-  <anime anidbid="17535" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17535" tvdbid="381536" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">
     <name>Bai Yao Pu Jing Shi Pia</name>
   </anime>
   <anime anidbid="17536" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -40560,7 +40560,7 @@
   <anime anidbid="14733" tvdbid="352327" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Wei, Kan Jian Er Duo La! (2019)</name>
   </anime>
-  <anime anidbid="14734" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14734" tvdbid="385812" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Spriggan (2022)</name>
   </anime>
   <anime anidbid="14735" tvdbid="262090" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">
@@ -40599,7 +40599,7 @@
   <anime anidbid="14746" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Dragon's Dogma</name>
   </anime>
-  <anime anidbid="14747" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14747" tvdbid="387060" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Vampire in the Garden</name>
   </anime>
   <anime anidbid="14748" tvdbid="402834" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -42510,7 +42510,7 @@
   <anime anidbid="15452" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Tian Yu</name>
   </anime>
-  <anime anidbid="15453" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15453" tvdbid="419444" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Zuihou De Zhaohuan Shi</name>
   </anime>
   <anime anidbid="15454" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -43426,7 +43426,7 @@
   <anime anidbid="15784" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Qin Xia</name>
   </anime>
-  <anime anidbid="15785" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15785" tvdbid="391299" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Yingxiong Zai Lin</name>
   </anime>
   <anime anidbid="15786" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -44278,7 +44278,7 @@
   <anime anidbid="16090" tvdbid="400584" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Re-Main</name>
   </anime>
-  <anime anidbid="16091" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="16091" tvdbid="363519" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Totsukuni no Shoujo (2022)</name>
   </anime>
   <anime anidbid="16092" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -45319,7 +45319,7 @@
   <anime anidbid="16511" tvdbid="408325" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Can Ci Pin: Fangzhu Xingkong</name>
   </anime>
-  <anime anidbid="16512" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="16512" tvdbid="407998" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Uchi no Shishou wa Shippo ga Nai</name>
   </anime>
   <anime anidbid="16513" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -47623,7 +47623,7 @@
   <anime anidbid="17335" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Ni Zhenshi Ge Tiancai</name>
   </anime>
-  <anime anidbid="17336" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17336" tvdbid="419448" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Yoru wa Neko to Issho</name>
   </anime>
   <anime anidbid="17337" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -47692,7 +47692,7 @@
   <anime anidbid="17360" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Kubo-san wa Boku o Yurusanai</name>
   </anime>
-  <anime anidbid="17361" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17361" tvdbid="250070" defaulttvdbseason="0" episodeoffset="2" tmdbid="" imdbid="">
     <name>Uta no Prince-sama: Maji Love Starish Tours - Tabi no Hajimari</name>
   </anime>
   <anime anidbid="17362" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -30978,7 +30978,7 @@
   <anime anidbid="11288" tvdbid="275582" defaulttvdbseason="0" episodeoffset="1" tmdbid="" imdbid="tt4168024">
     <name>Eiga Youkai Watch: Enma Daiou to Itsutsu no Monogatari Da Nyan!</name>
   </anime>
-  <anime anidbid="11289" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="11289" tvdbid="253182" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>DD Hokuto no Ken 2: Ichigo Aji+</name>
   </anime>
   <anime anidbid="11290" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -31533,7 +31533,7 @@
   <anime anidbid="11490" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Akuma no Kairozu</name>
   </anime>
-  <anime anidbid="11491" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="11491" tvdbid="272312" defaulttvdbseason="0" episodeoffset="1" tmdbid="" imdbid="">
     <name>Diabolik Lovers (2015)</name>
   </anime>
   <anime anidbid="11492" tvdbid="319985" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -32991,7 +32991,7 @@
   <anime anidbid="12034" tvdbid="329252" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Infini-T Force</name>
   </anime>
-  <anime anidbid="12035" tvdbid="314361" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="12035" tvdbid="314361" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Danganronpa 3: The End of Kibougamine Gakuen - Zetsubou Hen</name>
   </anime>
   <anime anidbid="12036" tvdbid="267437" defaulttvdbseason="0" episodeoffset="6" tmdbid="" imdbid="">
@@ -35501,7 +35501,7 @@
   <anime anidbid="12967" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Jie Mo Ren</name>
   </anime>
-  <anime anidbid="12968" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="12968" tvdbid="284439" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
     <name>Donten ni Warau: Gaiden</name>
   </anime>
   <anime anidbid="12969" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -40160,8 +40160,12 @@
   <anime anidbid="14597" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Kyou mo Tsuno ga Aru</name>
   </anime>
-  <anime anidbid="14598" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14598" tvdbid="373360" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Shaonu Qianxian: Renxing Xiao Juchang</name>
+    <mapping-list>
+      <mapping anidbseason="1" tvdbseason="1" start="1" end="12"/>
+	  <mapping anidbseason="1" tvdbseason="2" start="13" end="24" offset="-12"/>
+    </mapping-list>	
   </anime>
   <anime anidbid="14599" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Gaki ni Modotte Yarinaoshi!!!</name>
@@ -44877,7 +44881,7 @@
   <anime anidbid="16355" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Biao Ren</name>
   </anime>
-  <anime anidbid="16356" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="16356" tvdbid="413480" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Dawang Raoming</name>
   </anime>
   <anime anidbid="16357" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -45111,7 +45115,7 @@
   <anime anidbid="16435" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Douluo Dalu: Shan Yu Yu Lai</name>
   </anime>
-  <anime anidbid="16436" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="16436" tvdbid="415023" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>ELF Academy</name>
   </anime>
   <anime anidbid="16437" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/248 | https://thetvdb.com/index.php?tab=series&id=78918 | Season 2 previous mapping was removed or something? |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->