### PR TITLE
Fix Mushoku Tensei Special

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -43876,7 +43876,7 @@
   <anime anidbid="15954" tvdbid="371310" defaulttvdbseason="1" episodeoffset="11" tmdbid="" imdbid="">
     <name>Mushoku Tensei: Isekai Ittara Honki Dasu (2021)</name>
     <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0">;1-0;2-1;</mapping>
+      <mapping anidbseason="0" tvdbseason="0">;1-1;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="15955" tvdbid="337336" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -43876,7 +43876,7 @@
   <anime anidbid="15954" tvdbid="371310" defaulttvdbseason="1" episodeoffset="11" tmdbid="" imdbid="">
     <name>Mushoku Tensei: Isekai Ittara Honki Dasu (2021)</name>
     <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0">;1-1;</mapping>
+      <mapping anidbseason="0" tvdbseason="0" start="2" end="17" offset="-17">;1-1;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="15955" tvdbid="337336" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/15954 | https://thetvdb.com/index.php?tab=series&id=371310 | Updated mapping for Mushoku Tensei Special, as it is now SP01, not SP02 |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->