### PR TITLE
Map `Nokemono-tachi no Yoru` and `Sazanami Souji ni Shojo o Sasagu`

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -47239,7 +47239,7 @@
   <anime anidbid="17202" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Zannen na Ikimono Jiten (2022)</name>
   </anime>
-  <anime anidbid="17203" tvdbid="hentai" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17203" tvdbid="424563" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Sazanami Souji ni Shojo o Sasagu: Saa, Jikkuri Medemashou ka</name>
   </anime>
   <anime anidbid="17204" tvdbid="416588" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -48049,7 +48049,7 @@
   <anime anidbid="17487" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Kame no Koura wa Abarabone</name>
   </anime>
-  <anime anidbid="17488" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17488" tvdbid="421893" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Nokemono-tachi no Yoru</name>
   </anime>
   <anime anidbid="17489" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/17488 | https://thetvdb.com/index.php?tab=series&id=421893 | Season 1 `Nokemono-tachi no Yoru` map |
| https://anidb.net/anime/17203 | https://thetvdb.com/index.php?tab=series&id=424563 | Season 1 `Sazanami Souji ni Shojo o Sasagu` map, as tvdb entry was approved be the mods |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->