### PR TITLE
Remove Kill la Kill special mapping

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -27271,9 +27271,6 @@
   </anime>
   <anime anidbid="9875" tvdbid="272074" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Kill la Kill</name>
-    <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0">;1-2;</mapping>
-    </mapping-list>
   </anime>
   <anime anidbid="9877" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Joshikousei no Koshitsuki</name>


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/9875 | https://thetvdb.com/index.php?tab=series&id=272074 | Specials |

AniDB S1 is the same as TVDB s00e01, so no need for the current special mapping anymore. The other specials are technically not aligned right now, but I just submitted a creq to AniDB to rearrange their special order according to their own standards, which after being accepted would end up with all specials aligned with each other. I figured it was silly to set a special mapping for those when it would just have to be removed again as soon as the creq is accepted.

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->