### PR TITLE
Add mapping for `Itou Junji: Maniac` and `Uchi no Kaisha no Chiisai Senpai no Hanashi`

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -47944,7 +47944,7 @@
   <anime anidbid="17445" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Mabeobsa-ui Adeul Cory</name>
   </anime>
-  <anime anidbid="17446" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17446" tvdbid="421061" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Itou Junji: Maniac</name>
   </anime>
   <anime anidbid="17447" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -48574,7 +48574,7 @@
   <anime anidbid="17669" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Juedai Shuang Jiao</name>
   </anime>
-  <anime anidbid="17670" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17670" tvdbid="426080" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Uchi no Kaisha no Chiisai Senpai no Hanashi</name>
   </anime>
   <anime anidbid="17671" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/17446 | https://thetvdb.com/index.php?tab=series&id=421061 | Season 1 `Itou Junji: Maniac` mapping |
| https://anidb.net/anime/17670 | https://thetvdb.com/index.php?tab=series&id=426080 | Season 1 `Uchi no Kaisha no Chiisai Senpai no Hanashi` mapping |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->