### PR TITLE
fix Mahouka Koukou no Rettousei: Tsuioku Hen

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -44265,7 +44265,7 @@
   <anime anidbid="16080" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Kamiari Algorithm</name>
   </anime>
-  <anime anidbid="16081" tvdbid="movie" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="tt15497404">
+  <anime anidbid="16081" tvdbid="tv special" defaulttvdbseason="" episodeoffset="" tmdbid="1009176" imdbid="tt15497404">
     <name>Mahouka Koukou no Rettousei: Tsuioku Hen</name>
   </anime>
   <anime anidbid="16082" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -44265,7 +44265,7 @@
   <anime anidbid="16080" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Kamiari Algorithm</name>
   </anime>
-  <anime anidbid="16081" tvdbid="278329" defaulttvdbseason="0" episodeoffset="7" tmdbid="" imdbid="">
+  <anime anidbid="16081" tvdbid="movie" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="tt15497404">
     <name>Mahouka Koukou no Rettousei: Tsuioku Hen</name>
   </anime>
   <anime anidbid="16082" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
added the imdb id beceause Mahouka Koukou no Rettousei: Tsuioku Hen is not S00E07 and is not even listed as special on tvdb
S00E07 : https://thetvdb.com/series/the-irregular-at-magic-high-school/episodes/5741359
| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/16081 |https://www.imdb.com/title/tt15497404/  | Not in the tvdb series |