### PR TITLE
Update README to included other projects using anime-lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Anime mapping lists used by:
   - [MyAnimeList Plex Metadata Agent](https://github.com/Fribb/MyAnimeList.bundle)
   - [Ani-Sync Jellyfin Plugin](https://github.com/vosmiic/jellyfin-ani-sync) for [Jellyfin](https://jellyfin.org/)
   - [JellySeer](https://github.com/Fallenbagel/jellyseerr)
-  - [Medusa](https://github.com/pymedusa/Medusa)
   - [Overseer](https://github.com/sct/overseerr)
   
 These lists map information between [AniDB](https://anidb.net), [TheTVDB](https://www.thetvdb.com), [TMDB](https://www.themoviedb.org) and [IMDB](https://www.imdb.com).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Anime mapping lists used by:
   - [HTTP Anidb Metadata Agent (HAMA)](https://github.com/ZeroQI/Hama.bundle) for [Plex](https://plex.tv)
   - [Plex Meta Manager](https://github.com/meisnate12/Plex-Meta-Manager)
   - [MyAnimeList Plex Metadata Agent](https://github.com/Fribb/MyAnimeList.bundle)
-
+  - [Ani-Sync Jellyfin Plugin](https://github.com/vosmiic/jellyfin-ani-sync) for [Jellyfin](https://jellyfin.org/)
+  - [JellySeer](https://github.com/Fallenbagel/jellyseerr)
+  - [Medusa](https://github.com/pymedusa/Medusa)
 
 These lists map information between [AniDB](https://anidb.net), [TheTVDB](https://www.thetvdb.com), [TMDB](https://www.themoviedb.org) and [IMDB](https://www.imdb.com).
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Anime mapping lists used by:
   - [Ani-Sync Jellyfin Plugin](https://github.com/vosmiic/jellyfin-ani-sync) for [Jellyfin](https://jellyfin.org/)
   - [JellySeer](https://github.com/Fallenbagel/jellyseerr)
   - [Medusa](https://github.com/pymedusa/Medusa)
-
+  - [Overseer](https://github.com/sct/overseerr)
+  
 These lists map information between [AniDB](https://anidb.net), [TheTVDB](https://www.thetvdb.com), [TMDB](https://www.themoviedb.org) and [IMDB](https://www.imdb.com).
 
 The Lists

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This list contains groupings of anime titles that are suitable as movie sets (in
 
 ### anime-list-master.xml ###
 This list contains entries for every title on AniDb.net and serves as a template from which all the remaining lists are derived.
-Feel free to [contribute to it](/#contributing) if you notice missing or mismatched entries
+Feel free to [contribute to it](#contributing) if you notice missing or mismatched entries
 
 ### anime-list.xml ###
 The default list used by the scraper.  Contains all entries from the master list that are not empty or marked as "unknown".


### PR DESCRIPTION
Hi Team,

Just though I do the update to the README to adding in the other projects I mention in [my issue](https://github.com/Anime-Lists/anime-lists/issues/279#issue-1638501439)

This add in the following projects.

[Ani-Sync Jellyfin Plugin](https://github.com/vosmiic/jellyfin-ani-sync)
[JellySeer](https://github.com/Fallenbagel/jellyseerr)
~~[Medusa](https://github.com/pymedusa/Medusa)~~
[Overseer](https://github.com/sct/overseerr)
