### PR TITLE
Updates for 338 to 340 (Sore Yuke! Uchuu Senkan Yamamoto Youko)

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -1436,13 +1436,13 @@
   <anime anidbid="337" tvdbid="80583" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Shin Tenchi Muyou!</name>
   </anime>
-  <anime anidbid="338" tvdbid="106641" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="338" tvdbid="106641" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
     <name>Sore Yuke! Uchuu Senkan Yamamoto Youko</name>
   </anime>
-  <anime anidbid="339" tvdbid="106641" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="339" tvdbid="106641" defaulttvdbseason="0" episodeoffset="3" tmdbid="" imdbid="">
     <name>Sore Yuke! Uchuu Senkan Yamamoto Youko II</name>
   </anime>
-  <anime anidbid="340" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="340" tvdbid="106641" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Sore Yuke! Uchuu Senkan Yamamoto Youko (1999)</name>
   </anime>
   <anime anidbid="343" tvdbid="72775" defaulttvdbseason="4" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
Updated the Sore Yuke! Uchuu Senkan Yamamoto Youko as it was listed incorrectly.

* Change from Season 1 & 2 to Special with episode off set
* Added Sore Yuke! Uchuu Senkan Yamamoto Youko (1999) which is Season 01

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/338 | https://thetvdb.com/index.php?tab=series&id=106641 | Sore Yuke! Uchuu Senkan Yamamoto Youko - Specials - Ep 1-3 |
| https://anidb.net/anime/339 | https://thetvdb.com/index.php?tab=series&id=106641 | Sore Yuke! Uchuu Senkan Yamamoto Youko II - Specials - Ep 3-6 |
| https://anidb.net/anime/340 | https://thetvdb.com/index.php?tab=series&id=106641 | Sore Yuke! Uchuu Senkan Yamamoto Youko (1999) - Season 1 |