### PR TITLE
Minor fixes to Digimon Tamers Movies (1227 and 1475)

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -4549,7 +4549,7 @@
   <anime anidbid="1225" tvdbid="80787" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Comic Party Revolution</name>
   </anime>
-  <anime anidbid="1227" tvdbid="277575" defaulttvdbseason="0" episodeoffset="4" tmdbid="" imdbid="tt0810831">
+  <anime anidbid="1227" tvdbid="277575" defaulttvdbseason="0" episodeoffset="0" tmdbid="" imdbid="tt0810831">
     <name>Digimon Tamers: Boukensha-tachi no Tatakai</name>
   </anime>
   <anime anidbid="1229" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="72696" imdbid="">
@@ -5302,7 +5302,7 @@
   <anime anidbid="1474" tvdbid="81472" defaulttvdbseason="0" episodeoffset="10" tmdbid="" imdbid="tt0142247">
     <name>Dragon Ball Z: Zetsubou e no Hankou!! Nokosareta Chousenshi - Gohan to Trunks</name>
   </anime>
-  <anime anidbid="1475" tvdbid="277575" defaulttvdbseason="0" episodeoffset="5" tmdbid="" imdbid="tt0810833">
+  <anime anidbid="1475" tvdbid="277575" defaulttvdbseason="0" episodeoffset="1" tmdbid="" imdbid="tt0810833">
     <name>Digimon Tamers: Bousou Digimon Tokkyuu</name>
   </anime>
   <anime anidbid="1476" tvdbid="271770" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -4549,7 +4549,7 @@
   <anime anidbid="1225" tvdbid="80787" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Comic Party Revolution</name>
   </anime>
-  <anime anidbid="1227" tvdbid="277575" defaulttvdbseason="0" episodeoffset="0" tmdbid="" imdbid="tt0810831">
+  <anime anidbid="1227" tvdbid="277575" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0810831">
     <name>Digimon Tamers: Boukensha-tachi no Tatakai</name>
   </anime>
   <anime anidbid="1229" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="72696" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -4549,7 +4549,7 @@
   <anime anidbid="1225" tvdbid="80787" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Comic Party Revolution</name>
   </anime>
-  <anime anidbid="1227" tvdbid="277575 " defaulttvdbseason="0" episodeoffset="4" tmdbid="" imdbid="tt0810831">
+  <anime anidbid="1227" tvdbid="277575" defaulttvdbseason="0" episodeoffset="4" tmdbid="" imdbid="tt0810831">
     <name>Digimon Tamers: Boukensha-tachi no Tatakai</name>
   </anime>
   <anime anidbid="1229" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="72696" imdbid="">
@@ -5302,7 +5302,7 @@
   <anime anidbid="1474" tvdbid="81472" defaulttvdbseason="0" episodeoffset="10" tmdbid="" imdbid="tt0142247">
     <name>Dragon Ball Z: Zetsubou e no Hankou!! Nokosareta Chousenshi - Gohan to Trunks</name>
   </anime>
-  <anime anidbid="1475" tvdbid="277575 " defaulttvdbseason="0" episodeoffset="5" tmdbid="" imdbid="tt0810833">
+  <anime anidbid="1475" tvdbid="277575" defaulttvdbseason="0" episodeoffset="5" tmdbid="" imdbid="tt0810833">
     <name>Digimon Tamers: Bousou Digimon Tokkyuu</name>
   </anime>
   <anime anidbid="1476" tvdbid="271770" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/1227  | https://thetvdb.com/index.php?tab=series&id=277575 | Digimon Tamers: Boukensha-tachi no Tatakai (Digimon Tamers: Battle of Adventurers) - Fixed white space in TVDBID & Episodeoffset to 0|
| https://anidb.net/anime/1475 | https://thetvdb.com/index.php?tab=series&id=277575 | Digimon Tamers: Bousou Digimon Tokkyuu (Digimon Tamers: Runaway Locomon ) - Fixed white space in TVDBID & Episodeoffset to 1|
