### PR TITLE
tvdb updated Gundam witch to be season1 continuation 

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -48499,7 +48499,7 @@
   <anime anidbid="17643" tvdbid="391005" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Gokushufudou (2023)</name>
   </anime>
-  <anime anidbid="17644" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17644" tvdbid="372939" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">
     <name>Majutsushi Orphen Hagure Tabi: Urbanrama Hen</name>
   </anime>
   <anime anidbid="17645" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -42645,7 +42645,7 @@
   <anime anidbid="15500" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>A Day Before Us</name>
   </anime>
-  <anime anidbid="15501" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15501" tvdbid="392988" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Toutotsu ni Egypt Shin</name>
   </anime>
   <anime anidbid="15502" tvdbid="380402" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -45301,7 +45301,7 @@
   <anime anidbid="16507" tvdbid="272316" defaulttvdbseason="0" episodeoffset="3" tmdbid="" imdbid="">
     <name>Non Non Biyori Nonstop: Bukatsu o Ganbatta</name>
   </anime>
-  <anime anidbid="16508" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="16508" tvdbid="392988" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Toutotsu ni Egypt Shin 2</name>
   </anime>
   <anime anidbid="16509" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -48554,7 +48554,7 @@
       <mapping anidbseason="1" tvdbseason="0">;1-8+9;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="17648" tvdbid="418364" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17648" tvdbid="418364" defaulttvdbseason="1" episodeoffset="12" tmdbid="" imdbid="">
     <name>Kidou Senshi Gundam: Suisei no Majo (2023)</name>
   </anime>
   <anime anidbid="17649" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -39571,7 +39571,7 @@
   <anime anidbid="14380" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Tu Bian Yingxiong LEAF</name>
   </anime>
-  <anime anidbid="14381" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14381" tvdbid="352569" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Hangyaku-sei Million Arthur (2019)</name>
   </anime>
   <anime anidbid="14382" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -41351,7 +41351,7 @@
   <anime anidbid="15003" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt10621032">
     <name>Lupin Sansei: The First</name>
   </anime>
-  <anime anidbid="15004" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15004" tvdbid="379528" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Han Hua Ri Ji</name>
   </anime>
   <anime anidbid="15005" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -45933,7 +45933,7 @@
   <anime anidbid="16719" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Yi Ren Zhixia 4</name>
   </anime>
-  <anime anidbid="16720" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="16720" tvdbid="379528" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Han Hua Ri Ji Di Er Ji</name>
   </anime>
   <anime anidbid="16721" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -47067,7 +47067,7 @@
   <anime anidbid="17121" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Eiga Sore Ike! Anpanman: Dororin to Bakeru Carnival</name>
   </anime>
-  <anime anidbid="17122" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17122" tvdbid="379528" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">
     <name>Han Hua Ri Ji Di San Ji</name>
   </anime>
   <anime anidbid="17123" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -36286,7 +36286,7 @@
   <anime anidbid="13235" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Jianzhen Da he shang</name>
   </anime>
-  <anime anidbid="13237" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="13237" tvdbid="324710" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Gin no Guardian II</name>
   </anime>
   <anime anidbid="13238" tvdbid="344076" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -48554,7 +48554,7 @@
       <mapping anidbseason="1" tvdbseason="0">;1-8+9;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="17648" tvdbid="418364" defaulttvdbseason="1" episodeoffset="12" tmdbid="" imdbid="">
+  <anime anidbid="17648" tvdbid="418364" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Kidou Senshi Gundam: Suisei no Majo (2023)</name>
   </anime>
   <anime anidbid="17649" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -48554,7 +48554,7 @@
       <mapping anidbseason="1" tvdbseason="0">;1-8+9;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="17648" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17648" tvdbid="418364" defaulttvdbseason="1" episodeoffset="12" tmdbid="" imdbid="">
     <name>Kidou Senshi Gundam: Suisei no Majo (2023)</name>
   </anime>
   <anime anidbid="17649" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/17648 | https://thetvdb.com/index.php?tab=series&id=418364 | Season 1+ |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->