### PR TITLE
Update Gargantia on the Verdurous Planet specials mapping

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -26428,7 +26428,7 @@
   <anime anidbid="9556" tvdbid="267432" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Suisei no Gargantia</name>
     <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0">;1-14;2-15;3-1;4-2;5-3;6-4;7-5;8-6;9-7;10-8;11-9;12-10;13-11;14-12;15-13;</mapping>
+      <mapping anidbseason="0" tvdbseason="0">;1-15;2-16;3-1;4-2;5-3;6-4;7-5;8-6;9-7;10-8;11-9;12-10;13-11;14-12;15-13;16-14;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="9557" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt2573198">


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/9556 | https://thetvdb.com/index.php?tab=series&id=267432 | Specials |