### PR TITLE
Update README with notes about one-to-many and many-to-one mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ The mapping-list node consists of one or more **mapping** nodes with the followi
 
     The format for mapping individual episodes is: ` ;1-5;2-6;...; ` where the first number in each mapping is the AniDb.net episode number
     and the second is the corresponding theTVDB.com episode number for the season specified.
+
+    If a AniDb.net episode maps to multiple theTVDB.com episodes these are separated by `+`. For example ` ;1-1+2; ` if the AniDb.net episode 1 contains both theTVDB.com episodes 1 and 2.
+    Multiple AniDB.net episodes can map to the same theTVDB.com episode. For example ` ;1-1;2-1; ` if both AniDb.net episodes 1 and 2 are parts of theTVDB.com episode 1.
     
     AniDB trailer episodes with prefix T can be mapped by using episode numbers >= 201, T1 = 201. "Other" episodes can be mapped using episode numbers >= 401, O1 = 401.
 

--- a/README.md
+++ b/README.md
@@ -110,9 +110,8 @@ The mapping-list node consists of one or more **mapping** nodes with the followi
 
     The format for mapping individual episodes is: ` ;1-5;2-6;...; ` where the first number in each mapping is the AniDb.net episode number
     and the second is the corresponding theTVDB.com episode number for the season specified.
-
-    If a AniDb.net episode maps to multiple theTVDB.com episodes these are separated by `+`. For example ` ;1-1+2; ` if the AniDb.net episode 1 contains both theTVDB.com episodes 1 and 2.
-    Multiple AniDB.net episodes can map to the same theTVDB.com episode. For example ` ;1-1;2-1; ` if both AniDb.net episodes 1 and 2 are parts of theTVDB.com episode 1.
+    For a single AniDb.net episode to multiple theTVDB.com episodes, you can link the latter with `+`. For example ` ;1-1+2; ` if the AniDb.net episode 1 contains both theTVDB.com episodes 1 and 2.
+    Conversely, multiple AniDB.net episodes simply map to the same theTVDB.com episode. For example ` ;1-1;2-1; ` if AniDb.net episodes 1 and 2 are parts of theTVDB.com episode 1. (**` ;1+2-1; ` IS NOT VALID!**)
     
     AniDB trailer episodes with prefix T can be mapped by using episode numbers >= 201, T1 = 201. "Other" episodes can be mapped using episode numbers >= 401, O1 = 401.
 


### PR DESCRIPTION

<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

This fixes #339.

In addition to the readme, I also updated the episode mapping for Ling Qi, for which AniDb has half-lenght episodes and TVDB has full-lenght episodes.
 
| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/12656 | https://thetvdb.com/index.php?tab=series&id=321503 | Season 1 |


<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->