### PR TITLE
Add `Rascal Does Not Dream of` movie set and map movies as specials

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -48595,8 +48595,11 @@
   <anime anidbid="17639" tvdbid="426861" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>UniteUp!</name>
   </anime>
-  <anime anidbid="17640" tvdbid="movie" defaulttvdbseason="" episodeoffset="" tmdbid="1056803" imdbid="tt27348312">
+  <anime anidbid="17640" tvdbid="345596" defaulttvdbseason="0" episodeoffset="" tmdbid="1056803" imdbid="tt27348312">
     <name>Seishun Buta Yarou wa Odekake Sister no Yume o Minai</name>
+    <mapping-list>
+      <mapping anidbseason="1" tvdbseason="0">;1-7;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="17641" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Onmyouji</name>
@@ -49228,8 +49231,11 @@
   <anime anidbid="17861" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Urusei Yatsura (2024)</name>
   </anime>
-  <anime anidbid="17862" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17862" tvdbid="345596" defaulttvdbseason="0" episodeoffset="" tmdbid="1086591" imdbid="tt28036417">
     <name>Seishun Buta Yarou wa Ransel Girl no Yume o Minai</name>
+    <mapping-list>
+      <mapping anidbseason="1" tvdbseason="0">;1-8;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="17864" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Lycoris Recoil (Shinsaku Animation)</name>

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -39672,11 +39672,8 @@
   <anime anidbid="14396" tvdbid="367277" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Azur Lane the Animation</name>
   </anime>
-  <anime anidbid="14397" tvdbid="345596" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt10472884">
+  <anime anidbid="14397" tvdbid="345596" defaulttvdbseason="0" episodeoffset="5" tmdbid="" imdbid="tt10472884">
     <name>Seishun Buta Yarou wa Yumemiru Shoujo no Yume o Minai</name>
-    <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-6;</mapping>
-    </mapping-list>
   </anime>
   <anime anidbid="14398" tvdbid="361439" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Stand My Heroes: Piece of Truth</name>
@@ -48595,11 +48592,8 @@
   <anime anidbid="17639" tvdbid="426861" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>UniteUp!</name>
   </anime>
-  <anime anidbid="17640" tvdbid="345596" defaulttvdbseason="0" episodeoffset="" tmdbid="1056803" imdbid="tt27348312">
+  <anime anidbid="17640" tvdbid="345596" defaulttvdbseason="0" episodeoffset="6" tmdbid="1056803" imdbid="tt27348312">
     <name>Seishun Buta Yarou wa Odekake Sister no Yume o Minai</name>
-    <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-7;</mapping>
-    </mapping-list>
   </anime>
   <anime anidbid="17641" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Onmyouji</name>
@@ -49231,11 +49225,8 @@
   <anime anidbid="17861" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Urusei Yatsura (2024)</name>
   </anime>
-  <anime anidbid="17862" tvdbid="345596" defaulttvdbseason="0" episodeoffset="" tmdbid="1086591" imdbid="tt28036417">
+  <anime anidbid="17862" tvdbid="345596" defaulttvdbseason="0" episodeoffset="7" tmdbid="1086591" imdbid="tt28036417">
     <name>Seishun Buta Yarou wa Ransel Girl no Yume o Minai</name>
-    <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-8;</mapping>
-    </mapping-list>
   </anime>
   <anime anidbid="17864" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Lycoris Recoil (Shinsaku Animation)</name>

--- a/anime-movieset-list.xml
+++ b/anime-movieset-list.xml
@@ -2505,7 +2505,7 @@
       <title type="main" xml:lang="x-jat">Oshiri Tantei Collection</title>
     </titles>
   </set>
-    <set>
+  <set>
     <anime anidbid="14397">Seishun Buta Yarou wa Yumemiru Shoujo no Yume o Minai</anime>
     <anime anidbid="17640">Seishun Buta Yarou wa Odekake Sister no Yume o Minai</anime>
     <anime anidbid="17862">Seishun Buta Yarou wa Ransel Girl no Yume o Minai</anime>

--- a/anime-movieset-list.xml
+++ b/anime-movieset-list.xml
@@ -2510,8 +2510,8 @@
     <anime anidbid="17640">Seishun Buta Yarou wa Odekake Sister no Yume o Minai</anime>
     <anime anidbid="17862">Seishun Buta Yarou wa Ransel Girl no Yume o Minai</anime>
     <titles>
-      <title type="main" xml:lang="x-jat">Seishun Buta Yarou wa ... no Yume o Minai Collection</title>
-      <title type="official" xml:lang="en">Rascal Does Not Dream of ... Collection</title>
+      <title type="main" xml:lang="x-jat">Seishun Buta Yarou wa Bunny Girl Senpai no Yume o Minai Collection</title>
+      <title type="official" xml:lang="en">Rascal Does Not Dream of Bunny Girl Senpai Collection</title>
     </titles>
   </set>
 </anime-set-list>

--- a/anime-movieset-list.xml
+++ b/anime-movieset-list.xml
@@ -2505,4 +2505,13 @@
       <title type="main" xml:lang="x-jat">Oshiri Tantei Collection</title>
     </titles>
   </set>
+    <set>
+    <anime anidbid="14397">Seishun Buta Yarou wa Yumemiru Shoujo no Yume o Minai</anime>
+    <anime anidbid="17640">Seishun Buta Yarou wa Odekake Sister no Yume o Minai</anime>
+    <anime anidbid="17862">Seishun Buta Yarou wa Ransel Girl no Yume o Minai</anime>
+    <titles>
+      <title type="main" xml:lang="x-jat">Seishun Buta Yarou wa ... no Yume o Minai Collection</title>
+      <title type="official" xml:lang="en">Rascal Does Not Dream of ... Collection</title>
+    </titles>
+  </set>
 </anime-set-list>


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/17640 | https://thetvdb.com/index.php?tab=series&id=345596 | Map movie as tvdb special |
| https://anidb.net/anime/17862 | https://thetvdb.com/index.php?tab=series&id=345596 <br/> https://www.themoviedb.org/movie/1086591 <br/> https://www.imdb.com/title/tt28036417 | Map movie as tvdb special and map to IMDB and TMDB |

Added movie set, but the naming is kinda iffy.

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->