### PR TITLE
Add Danguard Ace special episode offsets.

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -6606,7 +6606,7 @@
   <anime anidbid="1917" tvdbid="183801" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Wakusei Robo Danguard Ace</name>
   </anime>
-  <anime anidbid="1918" tvdbid="183801" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0142971">
+  <anime anidbid="1918" tvdbid="183801" defaulttvdbseason="0" episodeoffset="5" tmdbid="" imdbid="tt0142971">
     <name>Wakusei Robo Danguard Ace Tai Konchuu Robot Gundan</name>
   </anime>
   <anime anidbid="1919" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -7576,7 +7576,7 @@
   <anime anidbid="2227" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt0204541">
     <name>Sekai Meisaku Douwa: Oyayubi Hime</name>
   </anime>
-  <anime anidbid="2228" tvdbid="183801" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0185757">
+  <anime anidbid="2228" tvdbid="183801" defaulttvdbseason="0" episodeoffset="4" tmdbid="" imdbid="tt0185757">
     <name>Wakusei Robo Danguard Ace: Uchuu Daikaisen</name>
   </anime>
   <anime anidbid="2229" tvdbid="85230" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt0316540">


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

Noticed both of these were currently blank, added the correct values.

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/1918 | https://thetvdb.com/index.php?tab=series&id=183801 | Special 6 |
| https://anidb.net/anime/2228 | https://thetvdb.com/index.php?tab=series&id=183801 | Special 5 |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->