### PR TITLE
Nights with a cat, season 02 and specials

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -47684,6 +47684,9 @@
   </anime>
   <anime anidbid="17336" tvdbid="419448" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Yoru wa Neko to Issho</name>
+    <mapping-list>
+      <mapping anidbseason="0" tvdbseason="0">;1-0;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="17337" tvdbid="419126" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Kaminaki Sekai no Kamisama Katsudou</name>
@@ -49041,7 +49044,7 @@
   <anime anidbid="17813" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Pucca 2</name>
   </anime>
-  <anime anidbid="17814" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17814" tvdbid="419448" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Yoru wa Neko to Issho (2023)</name>
   </anime>
   <anime anidbid="17815" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->
If I'm understanding everything right, the season 02 special doesn't need anything specified as it is a 1-1 match, but the season 1 special needs to be mapped to 0 because it would conflict with season 2's special otherwise.
| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/17814 | https://thetvdb.com/index.php?tab=series&id=419448 | Season 2 and special |
| https://anidb.net/anime/17336 | https://thetvdb.com/index.php?tab=series&id=419448 | Nonexistent special |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->