### PR TITLE
Fix one piece mapping

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -341,10 +341,32 @@
   <anime anidbid="68" tvdbid="73247" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Bubblegum Crisis</name>
   </anime>
-  <anime anidbid="69" tvdbid="81797" defaulttvdbseason="a" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="69" tvdbid="81797" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>One Piece</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-27;2-3;3-9;4-10;5-14;6-0;7-0;8-0;9-0;10-0;11-0;12-0;13-0;14-0;15-0;16-31;17-23;18-24;19-28;20-29;21-30;22-0;23-32;24-34;25-0;26-36;27-37;28-40;29-41;30-42;31-43;32-44;33-45</mapping>
+      <mapping anidbseason="1" tvdbseason="0">;590-39;</mapping>
+      <mapping anidbseason="1" tvdbseason="2" start="9" end="30" offset="-8"/>
+      <mapping anidbseason="1" tvdbseason="3" start="31" end="47" offset="-30"/>
+      <mapping anidbseason="1" tvdbseason="4" start="48" end="60" offset="-47"/>
+      <mapping anidbseason="1" tvdbseason="5" start="61" end="69" offset="-60"/>
+      <mapping anidbseason="1" tvdbseason="6" start="70" end="91" offset="-69"/>
+      <mapping anidbseason="1" tvdbseason="7" start="92" end="130" offset="-91"/>
+      <mapping anidbseason="1" tvdbseason="8" start="131" end="143" offset="-130"/>
+      <mapping anidbseason="1" tvdbseason="9" start="144" end="195" offset="-143"/>
+      <mapping anidbseason="1" tvdbseason="10" start="196" end="226" offset="-195"/>
+      <mapping anidbseason="1" tvdbseason="11" start="227" end="325" offset="-226"/>
+      <mapping anidbseason="1" tvdbseason="12" start="326" end="381" offset="-325"/>
+      <mapping anidbseason="1" tvdbseason="13" start="382" end="481" offset="-381"/>
+      <mapping anidbseason="1" tvdbseason="14" start="482" end="516" offset="-481"/>
+      <mapping anidbseason="1" tvdbseason="15" start="517" end="578" offset="-516"/>
+      <mapping anidbseason="1" tvdbseason="16" start="579" end="589" offset="-578"/>
+      <mapping anidbseason="1" tvdbseason="16" start="591" end="628" offset="-579"/>
+      <mapping anidbseason="1" tvdbseason="17" start="629" end="746" offset="-628"/>
+      <mapping anidbseason="1" tvdbseason="18" start="747" end="779" offset="-746"/>
+      <mapping anidbseason="1" tvdbseason="19" start="780" end="877" offset="-779"/>
+      <mapping anidbseason="1" tvdbseason="20" start="878" end="891" offset="-877"/>
+      <mapping anidbseason="1" tvdbseason="21" start="892" end="1200" offset="-891"/>
     </mapping-list>
   </anime>
   <anime anidbid="70" tvdbid="73616" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -341,11 +341,12 @@
   <anime anidbid="68" tvdbid="73247" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Bubblegum Crisis</name>
   </anime>
-  <anime anidbid="69" tvdbid="81797" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="69" tvdbid="81797" defaulttvdbseason="a" episodeoffset="-1" tmdbid="" imdbid="">
     <name>One Piece</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-27;2-3;3-9;4-10;5-14;6-0;7-0;8-0;9-0;10-0;11-0;12-0;13-0;14-0;15-0;16-31;17-23;18-24;19-28;20-29;21-30;22-0;23-32;24-34;25-0;26-36;27-37;28-40;29-41;30-42;31-43;32-44;33-45</mapping>
       <mapping anidbseason="1" tvdbseason="0">;590-39;</mapping>
+      <mapping anidbseason="1" tvdbseason="1" start="1" end="8" offset="0"/>
       <mapping anidbseason="1" tvdbseason="2" start="9" end="30" offset="-8"/>
       <mapping anidbseason="1" tvdbseason="3" start="31" end="47" offset="-30"/>
       <mapping anidbseason="1" tvdbseason="4" start="48" end="60" offset="-47"/>
@@ -361,12 +362,6 @@
       <mapping anidbseason="1" tvdbseason="14" start="482" end="516" offset="-481"/>
       <mapping anidbseason="1" tvdbseason="15" start="517" end="578" offset="-516"/>
       <mapping anidbseason="1" tvdbseason="16" start="579" end="589" offset="-578"/>
-      <mapping anidbseason="1" tvdbseason="16" start="591" end="628" offset="-579"/>
-      <mapping anidbseason="1" tvdbseason="17" start="629" end="746" offset="-628"/>
-      <mapping anidbseason="1" tvdbseason="18" start="747" end="779" offset="-746"/>
-      <mapping anidbseason="1" tvdbseason="19" start="780" end="877" offset="-779"/>
-      <mapping anidbseason="1" tvdbseason="20" start="878" end="891" offset="-877"/>
-      <mapping anidbseason="1" tvdbseason="21" start="892" end="1200" offset="-891"/>
     </mapping-list>
   </anime>
   <anime anidbid="70" tvdbid="73616" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/69 | https://thetvdb.com/index.php?tab=series&id=81797  | See below |

So one piece can't be mapped using only absolute numbers because anidb episode 590 is mapped to an special(aka season 0 ep 39) so all episodes starting from 591 should have an offset of -1. I've set the whole series offset to -1 and manually mapped the first 589 eps that have no offset.