### PR TITLE
Removed wrong mappings

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -2844,7 +2844,7 @@
   <anime anidbid="706" tvdbid="85073" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Geobreeders 2: Mouryou Yuugekitai File-XX Ransen Toppa</name>
   </anime>
-  <anime anidbid="708" tvdbid="79654" defaulttvdbseason="a" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="708" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Crayon Shin-chan</name>
   </anime>
   <anime anidbid="709" tvdbid="259842" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -11411,7 +11411,7 @@
   <anime anidbid="3625" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Hajime Ningen Gyatoruz</name>
   </anime>
-  <anime anidbid="3626" tvdbid="286895" defaulttvdbseason="a" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="3626" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Nintama Rantarou</name>
   </anime>
   <anime anidbid="3627" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/708 | https://thetvdb.com/index.php?tab=series&id=79654 | Removed mapping |
| https://anidb.net/anime/3626 | https://thetvdb.com/index.php?tab=series&id=286895 | Removed mapping |

So I've been implementing support for mapping using absolute numbers on my app and found those 2 are wrongly mapped:

- Shin Chan: has 1200 episodes in anidb but in tvdb absolute order it has 1411, I've seen some episodes are repeated multiple times(example check episode 1016 on tvdb absolute order)
- Nintama Rentarou: has no episodes in tvdb absolute ordering.

Those two seem like a nightmare to map manually but I believe it's better to not provide the mappings than to provide wrong ones.