### PR TITLE
Update Ginga Eiyuu Densetsu: Die Neue These mapping

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -37068,8 +37068,12 @@
   <anime anidbid="13472" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Fullmetal Panic! (Director's Cut)</name>
   </anime>
-  <anime anidbid="13473" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="13473" tvdbid="343237" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Ginga Eiyuu Densetsu: Die Neue These (2019)</name>
+    <mapping-list>
+      <mapping anidbseason="1" tvdbseason="2">;1-1+2+3;2-4+5+6;3-7+8+9;4-10+11+12;</mapping>
+      <mapping anidbseason="0" tvdbseason="2" start="401" end="412" offset="-400"/>
+    </mapping-list>
   </anime>
   <anime anidbid="13474" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Wangpai Yushi</name>
@@ -43425,8 +43429,12 @@
   <anime anidbid="15727" tvdbid="389235" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Sore dake ga Neck</name>
   </anime>
-  <anime anidbid="15728" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15728" tvdbid="343237" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">
     <name>Ginga Eiyuu Densetsu: Die Neue These - Gekitotsu</name>
+    <mapping-list>
+      <mapping anidbseason="1" tvdbseason="3">;1-1+2+3;2-4+5+6;3-7+8+9;4-10+11+12;</mapping>
+      <mapping anidbseason="0" tvdbseason="3" start="401" end="412" offset="-400"/>
+    </mapping-list>
   </anime>
   <anime anidbid="15729" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Cap Kakumei Bottleman</name>
@@ -46467,8 +46475,12 @@
   <anime anidbid="16862" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Gon Di Hanta: Ta Turan Xiangdao</name>
   </anime>
-  <anime anidbid="16863" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="16863" tvdbid="343237" defaulttvdbseason="4" episodeoffset="" tmdbid="" imdbid="">
     <name>Ginga Eiyuu Densetsu: Die Neue These - Sakubou</name>
+    <mapping-list>
+      <mapping anidbseason="1" tvdbseason="4">;1-1+2+3;2-4+5+6;3-7+8+9;4-10+11+12;</mapping>
+      <mapping anidbseason="0" tvdbseason="4" start="401" end="412" offset="-400"/>
+    </mapping-list>
   </anime>
   <anime anidbid="16864" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Hu Yao Xiao Hongniang Di Shiyi Ji</name>


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/13473 | https://thetvdb.com/index.php?tab=series&id=343237 | Movie/Series |
| https://anidb.net/anime/15728 | https://thetvdb.com/index.php?tab=series&id=343237 | Movie/Series |
| https://anidb.net/anime/16863 | https://thetvdb.com/index.php?tab=series&id=343237 | Movie/Series |

Personally I disagree with the way AniDB is handling these and think the "movies" and "episodes" should be switched; not even the anal mods over at TVDB are respecting the "first airing" as a movie or even have entries for it, but it doesn't seem like AniDB is interested in changing, so this mapping will have to do.