### PR TITLE
Add `Tensei Shitara Slime Datta Ken: Coleus no Yume` mapping

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -49339,7 +49339,7 @@
   <anime anidbid="17872" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Koumi-jima: Shuu 7 de Umeru Mesu-tachi</name>
   </anime>
-  <anime anidbid="17873" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17873" tvdbid="352408" defaulttvdbseason="0" episodeoffset="9" tmdbid="" imdbid="">
     <name>Tensei Shitara Slime Datta Ken: Coleus no Yume</name>
   </anime>
   <anime anidbid="17874" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/17873 | https://thetvdb.com/index.php?tab=series&id=352408 | Mapping `Tensei Shitara Slime Datta Ken: Coleus no Yume` OVAs |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->