### PR TITLE
Map `Xian Wang de Richang Shenghuo 4` and `Psycho-Pass Collection`

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -50333,7 +50333,7 @@
   <anime anidbid="18216" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Tadaima, Okaeri</name>
   </anime>
-  <anime anidbid="18217" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="18217" tvdbid="376751" defaulttvdbseason="4" episodeoffset="" tmdbid="" imdbid="">
     <name>Xian Wang de Richang Shenghuo 4</name>
   </anime>
   <anime anidbid="18218" tvdbid="388672" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-movieset-list.xml
+++ b/anime-movieset-list.xml
@@ -2514,4 +2514,11 @@
       <title type="main" xml:lang="x-jat">Oshiri Tantei Collection</title>
     </titles>
   </set>
+  <set>
+    <anime anidbid="10066">Gekijouban Psycho-Pass</anime>
+    <anime anidbid="17573">Gekijouban Psycho-Pass: Providence</anime>
+    <titles>
+      <title type="main" xml:lang="x-jat">Psycho-Pass Collection</title>
+    </titles>
+  </set>
 </anime-set-list>


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/18217 | https://thetvdb.com/index.php?tab=series&id=376751 | Season 1 `Xian Wang de Richang Shenghuo` |

Added movie set for Psycho-Pass full length movies
<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->