### PR TITLE
Fix TVDB mappings

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -895,11 +895,8 @@
   <anime anidbid="194" tvdbid="196721" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Momoiro Sisters</name>
   </anime>
-  <anime anidbid="195" tvdbid="70863" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="195" tvdbid="395150" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Rurouni Kenshin: Meiji Kenkaku Romantan - Seisou Hen</name>
-    <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-6;2-7;</mapping>
-    </mapping-list>
     <supplemental-info>
       <studio>Studio Deen</studio>
     </supplemental-info>
@@ -5249,7 +5246,7 @@
   <anime anidbid="1453" tvdbid="265216" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">
     <name>Gegege no Kitarou (1985)</name>
   </anime>
-  <anime anidbid="1454" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="1454" tvdbid="433093" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Gegege no Kitarou: Jigoku Hen</name>
   </anime>
   <anime anidbid="1455" tvdbid="265216" defaulttvdbseason="4" episodeoffset="" tmdbid="" imdbid="">
@@ -7835,7 +7832,7 @@
       <studio>Nippon Animation</studio>
     </supplemental-info>
   </anime>
-  <anime anidbid="2298" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="2298" tvdbid="83483" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Princess Sara</name>
     <supplemental-info>
       <studio>Nippon Animation</studio>
@@ -8057,7 +8054,7 @@
   <anime anidbid="2360" tvdbid="tv special" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="unknown">
     <name>Shiroi Kiba: White Fang Monogatari</name>
   </anime>
-  <anime anidbid="2361" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="2361" tvdbid="254903" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Ginga Hyouryuu Vifam</name>
   </anime>
   <anime anidbid="2362" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -13026,7 +13023,7 @@
   <anime anidbid="4427" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Mahou Shoujo Sae</name>
   </anime>
-  <anime anidbid="4428" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="4428" tvdbid="345113" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
     <name>Licca-chan Fushigi na Fushigi na Yunia Monogatari</name>
   </anime>
   <anime anidbid="4434" tvdbid="OVA" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="unknown">
@@ -17487,11 +17484,8 @@
       <mapping anidbseason="1" tvdbseason="0">;1-5;2-6;</mapping>
     </mapping-list>
   </anime>
-  <anime anidbid="6393" tvdbid="76932" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="6393" tvdbid="76932" defaulttvdbseason="0" episodeoffset="16" tmdbid="" imdbid="">
     <name>Ranma 1/2: Nettou Uta Gassen</name>
-    <mapping-list>
-      <mapping anidbseason="1" tvdbseason="0">;1-0;2-0;</mapping>
-    </mapping-list>
   </anime>
   <anime anidbid="6394" tvdbid="72459" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="tt1380954">
     <name>Sonic: Night of the WereHog - Sonic &amp; Chip Kyoufu no Kan</name>
@@ -24050,7 +24044,7 @@
   <anime anidbid="8679" tvdbid="255206" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Poyopoyo Kansatsu Nikki</name>
   </anime>
-  <anime anidbid="8680" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="8680" tvdbid="440409" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Gensei Shugoshin P-hyoro Ikka</name>
   </anime>
   <anime anidbid="8681" tvdbid="257765" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -24322,7 +24316,7 @@
   <anime anidbid="8769" tvdbid="music video" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Evidence</name>
   </anime>
-  <anime anidbid="8770" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="unknown">
+  <anime anidbid="8770" tvdbid="273042" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
     <name>Dororo</name>
   </anime>
   <anime anidbid="8772" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -42171,7 +42165,7 @@
   <anime anidbid="15278" tvdbid="399147" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Bishounen Tanteidan</name>
   </anime>
-  <anime anidbid="15279" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15279" tvdbid="78923" defaulttvdbseason="0" episodeoffset="16" tmdbid="" imdbid="">
     <name>Kimagure Orange Road: Futari no Koi no Repertoire</name>
   </anime>
   <anime anidbid="15280" tvdbid="374495" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -50279,7 +50273,7 @@
   <anime anidbid="18197" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Shu Tian Fu Mo Lu</name>
   </anime>
-  <anime anidbid="18199" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="18199" tvdbid="305074" defaulttvdbseason="0" episodeoffset="14" tmdbid="" imdbid="">
     <name>Boku no Hero Academia: Yuuei Heroes Battle</name>
   </anime>
   <anime anidbid="18200" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -895,8 +895,11 @@
   <anime anidbid="194" tvdbid="196721" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Momoiro Sisters</name>
   </anime>
-  <anime anidbid="195" tvdbid="395150" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="195" tvdbid="70863" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
     <name>Rurouni Kenshin: Meiji Kenkaku Romantan - Seisou Hen</name>
+    <mapping-list>
+      <mapping anidbseason="1" tvdbseason="0">;1-6;2-7;</mapping>
+    </mapping-list>
     <supplemental-info>
       <studio>Studio Deen</studio>
     </supplemental-info>


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

The most controversial change in this PR is to remap Rurouni Kenshin: Meiji Kenkaku Romantan - Seisou Hen from the special episodes of Rurouni Kenshin to its own tvdb entry. We can only map to one, so I think the dedicated entry is more appropriate. 

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/195 | https://thetvdb.com/index.php?tab=series&id=395150 | OVA |
| https://anidb.net/anime/1454 | https://thetvdb.com/index.php?tab=series&id=433093 | Season 1 |
| https://anidb.net/anime/2298 | https://thetvdb.com/index.php?tab=series&id=83483 | Season 1 |
| https://anidb.net/anime/2361 | https://thetvdb.com/index.php?tab=series&id=254903 | Season 1 |
| https://anidb.net/anime/4428 | https://thetvdb.com/index.php?tab=series&id=345113 | Specials |
| https://anidb.net/anime/6393 | https://thetvdb.com/index.php?tab=series&id=76932 | Specials |
| https://anidb.net/anime/8680 | https://thetvdb.com/index.php?tab=series&id=440409 | Season 1 |
| https://anidb.net/anime/8770 | https://thetvdb.com/index.php?tab=series&id=273042 | Special |
| https://anidb.net/anime/15279 | https://thetvdb.com/index.php?tab=series&id=78923 | Specials |
| https://anidb.net/anime/18199 | https://thetvdb.com/index.php?tab=series&id=305074 | Special |


<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->