### PR TITLE
Add season mappings

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -135,7 +135,7 @@
     </mapping-list>
     <before>;1-26;</before>
   </anime>
-  <anime anidbid="26" tvdbid="74125" defaulttvdbseason="a" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="26" tvdbid="74125" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Juuni Kokuki</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;2-0;</mapping>
@@ -466,7 +466,7 @@
       <studio>Gonzo</studio>
     </supplemental-info>
   </anime>
-  <anime anidbid="92" tvdbid="79857" defaulttvdbseason="a" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="92" tvdbid="79857" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Shaman King</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;4-5;5-4;</mapping>
@@ -1126,6 +1126,12 @@
   </anime>
   <anime anidbid="241" tvdbid="83105" defaulttvdbseason="a" episodeoffset="" tmdbid="" imdbid="">
     <name>Touch</name>
+    <mapping-list>
+      <mapping anidbseason="1" tvdbseason="1" start="1" end="27"/>
+      <mapping anidbseason="1" tvdbseason="2" start="28" end="56" offset="-27"/>
+      <mapping anidbseason="1" tvdbseason="3" start="57" end="79" offset="-56"/>
+      <mapping anidbseason="1" tvdbseason="4" start="80" end="101" offset="-79"/>
+    </mapping-list>
   </anime>
   <anime anidbid="242" tvdbid="85068" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Futari Ecchi</name>
@@ -9544,6 +9550,12 @@
   </anime>
   <anime anidbid="2855" tvdbid="80830" defaulttvdbseason="a" episodeoffset="" tmdbid="" imdbid="">
     <name>MAR Heaven</name>
+    <mapping-list>
+      <mapping anidbseason="1" tvdbseason="1" start="1" end="26"/>
+      <mapping anidbseason="1" tvdbseason="2" start="27" end="52" offset="-26"/>
+      <mapping anidbseason="1" tvdbseason="3" start="53" end="78" offset="-52"/>
+      <mapping anidbseason="1" tvdbseason="4" start="79" end="102" offset="-78"/>
+    </mapping-list>
   </anime>
   <anime anidbid="2857" tvdbid="OVA" defaulttvdbseason="1" episodeoffset="" tmdbid="410981" imdbid="">
     <name>Sentou Yousei Shoujo Tasukete! Maeve-chan</name>
@@ -12666,6 +12678,10 @@
   </anime>
   <anime anidbid="4264" tvdbid="79483" defaulttvdbseason="a" episodeoffset="" tmdbid="" imdbid="">
     <name>Kiba</name>
+    <mapping-list>
+      <mapping anidbseason="1" tvdbseason="1" start="1" end="26"/>
+      <mapping anidbseason="1" tvdbseason="2" start="27" end="51" offset="-26"/>
+    </mapping-list>
   </anime>
   <anime anidbid="4265" tvdbid="79456" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Glass no Kantai</name>


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->
So Juuni Kokui and the original Shaman King is currently set to absolute order, despite only having one season in TVDB (in which the episode order is the same as in the absolute order). This PR re-maps those series to season 1 instead which is more consistent with other one-season-series. The alternative is to keep absolute order, but also add an explicit mapping for all episodes to season 1, which seems a bit unnecessary.


| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/26 | https://thetvdb.com/index.php?tab=series&id=74125 | map to single season |
| https://anidb.net/anime/92 | https://thetvdb.com/index.php?tab=series&id=79857 | map to single season |
| https://anidb.net/anime/241 | https://thetvdb.com/index.php?tab=series&id=83105 | Add Season map |
| https://anidb.net/anime/2855 | https://thetvdb.com/index.php?tab=series&id=80830 | Add Season map |
| https://anidb.net/anime/4264 | https://thetvdb.com/index.php?tab=series&id=79483 | Add Season map |


<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->