### PR TITLE
Add season listings with unknown ending

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -352,6 +352,27 @@
     <name>One Piece</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-27;2-3;3-9;4-10;5-14;6-0;7-0;8-0;9-0;10-0;11-0;12-0;13-0;14-0;15-0;16-31;17-23;18-24;19-28;20-29;21-30;22-0;23-32;24-34;25-0;26-36;27-37;28-40;29-41;30-42;31-43;32-44;33-45</mapping>
+      <mapping anidbseason="1" tvdbseason="2" start="9" end="30" offset="-8"/>
+      <mapping anidbseason="1" tvdbseason="3" start="31" end="47" offset="-30"/>
+      <mapping anidbseason="1" tvdbseason="4" start="48" end="60" offset="-47"/>
+      <mapping anidbseason="1" tvdbseason="5" start="61" end="69" offset="-60"/>
+      <mapping anidbseason="1" tvdbseason="6" start="70" end="91" offset="-69"/>
+      <mapping anidbseason="1" tvdbseason="7" start="92" end="130" offset="-91"/>
+      <mapping anidbseason="1" tvdbseason="8" start="131" end="143" offset="-130"/>
+      <mapping anidbseason="1" tvdbseason="9" start="144" end="195" offset="-143"/>
+      <mapping anidbseason="1" tvdbseason="10" start="196" end="226" offset="-195"/>
+      <mapping anidbseason="1" tvdbseason="11" start="227" end="325" offset="-226"/>
+      <mapping anidbseason="1" tvdbseason="12" start="326" end="381" offset="-325"/>
+      <mapping anidbseason="1" tvdbseason="13" start="382" end="481" offset="-381"/>
+      <mapping anidbseason="1" tvdbseason="14" start="482" end="516" offset="-481"/>
+      <mapping anidbseason="1" tvdbseason="15" start="517" end="578" offset="-516"/>
+      <mapping anidbseason="1" tvdbseason="16" start="579" end="628" offset="-578"/>
+	  <mapping anidbseason="1" tvdbseason="17" start="629" end="746" offset="-628"/>
+	  <mapping anidbseason="1" tvdbseason="18" start="747" end="779" offset="-746"/>
+	  <mapping anidbseason="1" tvdbseason="19" start="780" end="877" offset="-779"/>
+	  <mapping anidbseason="1" tvdbseason="20" start="878" end="891" offset="-877"/>
+	  <mapping anidbseason="1" tvdbseason="21" start="892" end="1085" offset="-891"/>
+	  <mapping anidbseason="1" tvdbseason="22" start="1086" offset="-1085"/>
     </mapping-list>
   </anime>
   <anime anidbid="70" tvdbid="73616" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -1232,6 +1253,37 @@
     <name>Meitantei Conan</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-0;2-0;</mapping>
+      <mapping anidbseason="1" tvdbseason="2" start="29" end="54" offset="-28"/>
+      <mapping anidbseason="1" tvdbseason="3" start="55" end="82" offset="-54"/>
+      <mapping anidbseason="1" tvdbseason="4" start="83" end="106" offset="-82"/>
+      <mapping anidbseason="1" tvdbseason="5" start="107" end="134" offset="-106"/>
+      <mapping anidbseason="1" tvdbseason="6" start="135" end="162" offset="-134"/>
+      <mapping anidbseason="1" tvdbseason="7" start="163" end="193" offset="-162"/>
+      <mapping anidbseason="1" tvdbseason="8" start="194" end="219" offset="-193"/>
+      <mapping anidbseason="1" tvdbseason="9" start="220" end="254" offset="-219"/>
+      <mapping anidbseason="1" tvdbseason="10" start="255" end="285" offset="-254"/>
+      <mapping anidbseason="1" tvdbseason="11" start="286" end="315" offset="-285"/>
+      <mapping anidbseason="1" tvdbseason="12" start="316" end="353" offset="-315"/>
+      <mapping anidbseason="1" tvdbseason="13" start="354" end="389" offset="-353"/>
+      <mapping anidbseason="1" tvdbseason="14" start="390" end="426" offset="-389"/>
+      <mapping anidbseason="1" tvdbseason="15" start="427" end="465" offset="-426"/>
+      <mapping anidbseason="1" tvdbseason="16" start="466" end="490" offset="-465"/>
+      <mapping anidbseason="1" tvdbseason="17" start="491" end="523" offset="-490"/>
+      <mapping anidbseason="1" tvdbseason="18" start="524" end="565" offset="-523"/>
+      <mapping anidbseason="1" tvdbseason="19" start="566" end="605" offset="-565"/>
+      <mapping anidbseason="1" tvdbseason="20" start="606" end="645" offset="-605"/>
+      <mapping anidbseason="1" tvdbseason="21" start="646" end="680" offset="-645"/>
+      <mapping anidbseason="1" tvdbseason="22" start="681" end="723" offset="-680"/>
+      <mapping anidbseason="1" tvdbseason="23" start="724" end="762" offset="-723"/>
+      <mapping anidbseason="1" tvdbseason="24" start="763" end="803" offset="-762"/>
+      <mapping anidbseason="1" tvdbseason="25" start="804" end="886" offset="-803"/>
+      <mapping anidbseason="1" tvdbseason="26" start="887" end="926" offset="-886"/>
+      <mapping anidbseason="1" tvdbseason="27" start="927" end="964" offset="-926"/>
+      <mapping anidbseason="1" tvdbseason="28" start="965" end="992" offset="-964"/>
+      <mapping anidbseason="1" tvdbseason="29" start="993" end="1032" offset="-992"/>
+      <mapping anidbseason="1" tvdbseason="30" start="1033" end="1067" offset="-1032"/>
+      <mapping anidbseason="1" tvdbseason="31" start="1068" end="1108" offset="-1067"/>
+      <mapping anidbseason="1" tvdbseason="32" start="1109" offset="-1108"/>
     </mapping-list>
   </anime>
   <anime anidbid="267" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -367,12 +367,12 @@
       <mapping anidbseason="1" tvdbseason="14" start="482" end="516" offset="-481"/>
       <mapping anidbseason="1" tvdbseason="15" start="517" end="578" offset="-516"/>
       <mapping anidbseason="1" tvdbseason="16" start="579" end="628" offset="-578"/>
-	  <mapping anidbseason="1" tvdbseason="17" start="629" end="746" offset="-628"/>
-	  <mapping anidbseason="1" tvdbseason="18" start="747" end="779" offset="-746"/>
-	  <mapping anidbseason="1" tvdbseason="19" start="780" end="877" offset="-779"/>
-	  <mapping anidbseason="1" tvdbseason="20" start="878" end="891" offset="-877"/>
-	  <mapping anidbseason="1" tvdbseason="21" start="892" end="1085" offset="-891"/>
-	  <mapping anidbseason="1" tvdbseason="22" start="1086" offset="-1085"/>
+      <mapping anidbseason="1" tvdbseason="17" start="629" end="746" offset="-628"/>
+      <mapping anidbseason="1" tvdbseason="18" start="747" end="779" offset="-746"/>
+      <mapping anidbseason="1" tvdbseason="19" start="780" end="877" offset="-779"/>
+      <mapping anidbseason="1" tvdbseason="20" start="878" end="891" offset="-877"/>
+      <mapping anidbseason="1" tvdbseason="21" start="892" end="1085" offset="-891"/>
+      <mapping anidbseason="1" tvdbseason="22" start="1086" offset="-1085"/>
     </mapping-list>
   </anime>
   <anime anidbid="70" tvdbid="73616" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
One Piece and Detective Conan. To the best of my knowledge, these are the only two other edge cases where the current season cannot have a defined end point. TVDB is dividing Super Dragon Ball Heroes (Added in #426) and One Piece by arc, and Detective Conan annually. None are really predictable until they're closer to finishing.

<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/69 | https://thetvdb.com/index.php?tab=series&id=81797 | Seasons 2-22 |
| https://anidb.net/anime/266 | https://thetvdb.com/index.php?tab=series&id=72454 | Seasons 2-32 |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->