### PR TITLE
Add TVDB id for Amai Choubatsu

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -38175,7 +38175,7 @@
   <anime anidbid="13805" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Haru no Niji no Soushiki</name>
   </anime>
-  <anime anidbid="13806" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="13806" tvdbid="345341" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Amai Choubatsu: Watashi wa Kanshu Sen'you Pet</name>
   </anime>
   <anime anidbid="13807" tvdbid="275582" defaulttvdbseason="4" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/13806 | https://thetvdb.com/index.php?tab=series&id= 345341 |  |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->