### PR TITLE
King Kong 1966 and Koala Boy fix

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -11610,7 +11610,7 @@
   <anime anidbid="3641" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Pinocchio no Bouken</name>
   </anime>
-  <anime anidbid="3642" tvdbid="88131 " defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="3642" tvdbid="88131" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>King Kong</name>
     <mapping-list>
       <mapping anidbseason="1" tvdbseason="1">;1-1+2+3;2-4+5+6;3-7+8+9;4-10+11+12;5-13+14+15;6-16+17+18;7-19+20+21;8-22+23+24;9-25+26+27;10-28+29+30;11-31+32+33;12-34+35+36;12-37+38+39;13-40+41+42;14-43+44+45;15-46+47+48;16-49+50+51;17-52+53+54;18-55+56+57;19-58+59+60;20-61+62+63;21-64+65+66;22-67+68+69;22-70+71+72;</mapping>

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -11610,8 +11610,11 @@
   <anime anidbid="3641" tvdbid="unknown" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Pinocchio no Bouken</name>
   </anime>
-  <anime anidbid="3642" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="3642" tvdbid="88131 " defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>King Kong</name>
+    <mapping-list>
+      <mapping anidbseason="1" tvdbseason="1">;1-1+2+3;2-4+5+6;3-7+8+9;4-10+11+12;5-13+14+15;6-16+17+18;7-19+20+21;8-22+23+24;9-25+26+27;10-28+29+30;11-31+32+33;12-34+35+36;12-37+38+39;13-40+41+42;14-43+44+45;15-46+47+48;16-49+50+51;17-52+53+54;18-55+56+57;19-58+59+60;20-61+62+63;21-64+65+66;22-67+68+69;22-70+71+72;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="3643" tvdbid="79194" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
     <name>School Rumble: Ichi Gakki Hoshuu</name>
@@ -16257,7 +16260,7 @@
   <anime anidbid="5747" tvdbid="267881" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Koala Boy Kocky</name>
     <mapping-list>
-      <mapping anidbseason="1" tvdbseason="3">;1-1+2;2-3+4;3-5+6;4-7+8;5-9+10;6-11+12;7-13+14;8-15+16;9-17+18;10-19+20;11-21+22;12-23+24;13-25+26;14-27+28;15-29+30;16-31+32;17-33+34;18-35+36;19-37+38;20-39+40;21-41+42;22-43+44;23-45+46;24-47+48;25-49+50;26-51+52;</mapping>
+      <mapping anidbseason="1" tvdbseason="1">;1-1+2;2-3+4;3-5+6;4-7+8;5-9+10;6-11+12;7-13+14;8-15+16;9-17+18;10-19+20;11-21+22;12-23+24;13-25+26;14-27+28;15-29+30;16-31+32;17-33+34;18-35+36;19-37+38;20-39+40;21-41+42;22-43+44;23-45+46;24-47+48;25-49+50;26-51+52;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="5749" tvdbid="80158" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

Made a slight mistake with the previous Koala Boy submission that's been corrected.

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/3642 | https://thetvdb.com/index.php?tab=series&id=88131 | Season 1 |
| https://anidb.net/anime/5747 | https://thetvdb.com/index.php?tab=series&id=267881 | Season 1 fix |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->