### PR TITLE
Add mapping for `Mo Dao Zushi`

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -39970,7 +39970,7 @@
   <anime anidbid="14427" tvdbid="356310" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Choujigen Kakumei Anime: Dimension High School</name>
   </anime>
-  <anime anidbid="14428" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="14428" tvdbid="341295" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Mo Dao Zushi: Xian Yun Pian</name>
   </anime>
   <anime anidbid="14429" tvdbid="hentai" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
@@ -43276,7 +43276,7 @@
   <anime anidbid="15616" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Mo Duzhe</name>
   </anime>
-  <anime anidbid="15617" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="15617" tvdbid="386257" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Mo Dao Zushi Q</name>
   </anime>
   <anime anidbid="15618" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
@@ -45924,7 +45924,7 @@
   <anime anidbid="16617" tvdbid="310311" defaulttvdbseason="10" episodeoffset="" tmdbid="" imdbid="">
     <name>Hu Yao Xiao Hongniang: Liang Sheng Hua Pian</name>
   </anime>
-  <anime anidbid="16618" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="16618" tvdbid="341295" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">
     <name>Mo Dao Zushi: Wanjie Pian</name>
   </anime>
   <anime anidbid="16619" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/14428 | https://thetvdb.com/index.php?tab=series&id=341295 | Season 2 `Mo Dao Zushi` mapping |
| https://anidb.net/anime/17821 | https://thetvdb.com/index.php?tab=series&id=341295 | Season 3 `Mo Dao Zushi` mapping |
| https://anidb.net/anime/15617 | https://thetvdb.com/index.php?tab=series&id=386257 | Season 1 `Mo Dao Zushi Q` mapping |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->