### PR TITLE
Map `Dead Dead Demon's Dededededestruction` as other order

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -47761,7 +47761,7 @@
   <anime anidbid="17272" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Sora no Yukisaki</name>
   </anime>
-  <anime anidbid="17273" tvdbid="418123" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt28813303,tt28813376">
+  <anime anidbid="17273" tvdbid="418123" defaulttvdbseason="1" episodeoffset="" tmdbid="1172228,1172229" imdbid="">
     <name>Dead Dead Demon's Dededededestruction</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;401-1;</mapping>

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -47761,11 +47761,12 @@
   <anime anidbid="17272" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Sora no Yukisaki</name>
   </anime>
-  <anime anidbid="17273" tvdbid="418123" defaulttvdbseason="1" episodeoffset="" tmdbid="1172228,1172229" imdbid="">
+  <anime anidbid="17273" tvdbid="418123" defaulttvdbseason="1" episodeoffset="" tmdbid="1172228,1172229" imdbid="tt28813303,tt28813376">
     <name>Dead Dead Demon's Dededededestruction</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;401-1;</mapping>
       <mapping anidbseason="0" tvdbseason="1" start="402" end="418" offset="-401"/>
+      <mapping anidbseason="1" tvdbseason="1">;1-1+2+3+4+5+6+7+8+9;2-10+11+12+13+14+15+16+17+18;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="17274" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -47761,8 +47761,12 @@
   <anime anidbid="17272" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Sora no Yukisaki</name>
   </anime>
-  <anime anidbid="17273" tvdbid="418123" defaulttvdbseason="1" episodeoffset="" tmdbid="1172228,1172229" imdbid="">
+  <anime anidbid="17273" tvdbid="418123" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="tt28813303,tt28813376">
     <name>Dead Dead Demon's Dededededestruction</name>
+    <mapping-list>
+      <mapping anidbseason="0" tvdbseason="0">;401-1;</mapping>
+      <mapping anidbseason="0" tvdbseason="1" start="402" end="418" offset="-401"/>
+    </mapping-list>
   </anime>
   <anime anidbid="17274" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Kengan Ashura (2023)</name>


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/17273 | https://thetvdb.com/index.php?tab=series&id=418123 | Mapping `Dead Dead Demon's Dededededestruction` as other order |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->