### PR TITLE
Add new special mapping for `Boku no Kokoro no Yabai Yatsu`

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -48542,9 +48542,6 @@
   </anime>
   <anime anidbid="17547" tvdbid="422981" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Boku no Kokoro no Yabai Yatsu</name>
-    <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0">;1-0;2-1;</mapping>
-    </mapping-list>
   </anime>
   <anime anidbid="17548" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Zhu Xian</name>
@@ -50028,6 +50025,9 @@
   </anime>
   <anime anidbid="18066" tvdbid="422981" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Boku no Kokoro no Yabai Yatsu (2024)</name>
+    <mapping-list>
+      <mapping anidbseason="0" tvdbseason="0">;1-1;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="18067" tvdbid="348545" defaulttvdbseason="5" episodeoffset="" tmdbid="" imdbid="">
     <name>Kimetsu no Yaiba: Hashira Geiko Hen</name>

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -48542,6 +48542,9 @@
   </anime>
   <anime anidbid="17547" tvdbid="422981" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Boku no Kokoro no Yabai Yatsu</name>
+    <mapping-list>
+      <mapping anidbseason="0" tvdbseason="0">;1-0;2-0;</mapping>
+    </mapping-list>
   </anime>
   <anime anidbid="17548" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Zhu Xian</name>
@@ -50025,9 +50028,6 @@
   </anime>
   <anime anidbid="18066" tvdbid="422981" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Boku no Kokoro no Yabai Yatsu (2024)</name>
-    <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0">;1-1;</mapping>
-    </mapping-list>
   </anime>
   <anime anidbid="18067" tvdbid="348545" defaulttvdbseason="5" episodeoffset="" tmdbid="" imdbid="">
     <name>Kimetsu no Yaiba: Hashira Geiko Hen</name>


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/18066 | https://thetvdb.com/index.php?tab=series&id=422981 | Mapping `Boku no Kokoro no Yabai Yatsu` special as it is now part of TV-2 |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->