### PR TITLE
Fix mapping for `NieR:Automata Ver1.1a (2024)`

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -50222,7 +50222,7 @@
   <anime anidbid="18133" tvdbid="437517" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Naze Boku no Sekai o Dare mo Oboeteinai no ka?</name>
   </anime>
-  <anime anidbid="18134" tvdbid="416998" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="18134" tvdbid="416998" defaulttvdbseason="1" episodeoffset="12" tmdbid="" imdbid="">
     <name>NieR:Automata Ver1.1a (2024)</name>
   </anime>
   <anime anidbid="18135" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/18134 | https://thetvdb.com/index.php?tab=series&id=416998 | Fix Season 1 Part 2 `NieR:Automata Ver1.1a` mapping |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->