### PR TITLE
add second special for Tensei Shitara Slime Datta Ken (2024)

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -49009,7 +49009,7 @@
   <anime anidbid="17709" tvdbid="352408" defaulttvdbseason="3" episodeoffset="" tmdbid="" imdbid="">
     <name>Tensei Shitara Slime Datta Ken (2024)</name>
     <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0">;1-13;</mapping>
+      <mapping anidbseason="0" tvdbseason="0">;1-13;2-14;</mapping>
     </mapping-list>
   </anime>
   <anime anidbid="17710" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/17709 | https://thetvdb.com/index.php?tab=series&id=352408 | There is currently no existing entry for this on TVDB, however without this mapping it fails to remap this episode and duplicates it as special 2. This is the likely episode entry for the special. |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->