### PR TITLE
Added Kengan Ashura Season 2

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -47757,7 +47757,7 @@
   <anime anidbid="17273" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="1172228,1172229" imdbid="tt28813303,tt28813376">
     <name>Dead Dead Demon's Dededededestruction</name>
   </anime>
-  <anime anidbid="17274" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="17274" tvdbid="354179" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Kengan Ashura (2023)</name>
   </anime>
   <anime anidbid="17275" tvdbid="402475" defaulttvdbseason="1" episodeoffset="12" tmdbid="" imdbid="">


### PR DESCRIPTION
| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/17274 | https://thetvdb.com/index.php?tab=series&id=354179 | Season 2 |

Also I've seen there's an entry for anidbid 18762 "Kengan Ashura (2024)" in anime-list-master.xml which was the second part of the second season but seems like it got deleted and all S2 episodes were included in "Kengan Ashura (2023)" (this is the one im mapping here). Not sure if it should be deleted from the file so I didn't touch it.
