### PR TITLE
Add mapping for `High Card: The Flowers Bloom`

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -52486,7 +52486,7 @@
   <anime anidbid="18933" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
     <name>Zongmen Li Chule Wo Dou Shi Wodi</name>
   </anime>
-  <anime anidbid="18934" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">
+  <anime anidbid="18934" tvdbid="404525" defaulttvdbseason="0" episodeoffset="" tmdbid="" imdbid="">
     <name>High Card: The Flowers Bloom</name>
   </anime>
   <anime anidbid="18935" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/18934 | https://thetvdb.com/index.php?tab=series&id=404525 | Mapping Special `High Card: The Flowers Bloom` |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->