### PR TITLE
Fix kokoro connect special episode mappings

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -24380,9 +24380,6 @@
   </anime>
   <anime anidbid="8742" tvdbid="259647" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Kokoro Connect</name>
-    <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0">;1-14;2-15;3-16;4-17;</mapping>
-    </mapping-list>
   </anime>
   <anime anidbid="8743" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="unknown">
     <name>Ryoku Tama Shinshi</name>

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -24381,9 +24381,8 @@
   <anime anidbid="8742" tvdbid="259647" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">
     <name>Kokoro Connect</name>
     <mapping-list>
-      <mapping anidbseason="0" tvdbseason="1">;1-14;2-15;3-16;4-17;</mapping>
+      <mapping anidbseason="0" tvdbseason="0">;1-14;2-15;3-16;4-17;</mapping>
     </mapping-list>
-    <before>;1-14;2-15;3-16;4-17;</before>
   </anime>
   <anime anidbid="8743" tvdbid="movie" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="unknown">
     <name>Ryoku Tama Shinshi</name>


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/8742 | https://thetvdb.com/index.php?tab=series&id=259647 | Reordered Episodes: Fixes the special episode mapping as it is now in seasonNumber: 0 in TVDB |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->