### PR TITLE
fix Kage no Jitsuryokusha ni Naritakute! 2nd Season specials mapping

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -49468,8 +49468,8 @@
   <anime anidbid="17877" tvdbid="407520" defaulttvdbseason="2" episodeoffset="" tmdbid="" imdbid="">
     <name>Kage no Jitsuryokusha ni Naritakute! 2nd Season</name>
     <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0" start="1" end="4" offset="16"/>
-      <mapping anidbseason="0" tvdbseason="0" start="5" end="12" offset="17"/>
+      <mapping anidbseason="0" tvdbseason="0" start="1" end="4" offset="17"/>
+      <mapping anidbseason="0" tvdbseason="0" start="5" end="12" offset="18"/>
     </mapping-list>
   </anime>
   <anime anidbid="17878" tvdbid="431495" defaulttvdbseason="1" episodeoffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/17877 | https://thetvdb.com/index.php?tab=series&id=407520 | Fix specials offset |

the offsets are 1 out with the current TVDB mappings.

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id=407520 | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->