### PR TITLE
Add mapping for `Fangkai Nage Nuwu (2026)`

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -54724,7 +54724,7 @@
   <anime anidbid="19715" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbtv="" tmdbseason="" tmdboffset="" tmdbid="" imdbid="">
     <name>Wei Miao Rensheng</name>
   </anime>
-  <anime anidbid="19716" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbtv="" tmdbseason="" tmdboffset="" tmdbid="" imdbid="">
+  <anime anidbid="19716" tvdbid="474881" defaulttvdbseason="1" episodeoffset="" tmdbtv="298026" tmdbseason="1" tmdboffset="" tmdbid="" imdbid="">
     <name>Fangkai Nage Nuwu (2026)</name>
   </anime>
   <anime anidbid="19717" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbtv="" tmdbseason="" tmdboffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/19716 | https://thetvdb.com/index.php?tab=series&id=474881<br/> https://www.themoviedb.org/tv/298026 | Mapping `Fangkai Nage Nuwu (2026)` |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id= | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->