### PR TITLE
Cardcaptor Sakura: set absolute defaulttvdbseason

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -557,6 +557,7 @@
     <name>Cardcaptor Sakura</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-3;2-4;3-5;4-0;5-6;6-0;7-0;8-0;9-0;10-0;</mapping>
+      <mapping anidbseason="1" tvdbseason="1" start="1" end="35"/>
       <mapping anidbseason="1" tvdbseason="2" start="36" end="46" offset="-35"/>
       <mapping anidbseason="1" tvdbseason="3" start="47" end="70" offset="-46"/>
     </mapping-list>

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -553,7 +553,7 @@
   <anime anidbid="101" tvdbid="74539" defaulttvdbseason="1" episodeoffset="" tmdbtv="34170" tmdbseason="1" tmdboffset="" tmdbid="" imdbid="">
     <name>Jikuu Tenshou Nazca</name>
   </anime>
-  <anime anidbid="102" tvdbid="70668" defaulttvdbseason="1" episodeoffset="" tmdbtv="35790" tmdbseason="1" tmdboffset="" tmdbid="" imdbid="">
+  <anime anidbid="102" tvdbid="70668" defaulttvdbseason="a" episodeoffset="" tmdbtv="35790" tmdbseason="1" tmdboffset="" tmdbid="" imdbid="">
     <name>Cardcaptor Sakura</name>
     <mapping-list>
       <mapping anidbseason="0" tvdbseason="0">;1-3;2-4;3-5;4-0;5-6;6-0;7-0;8-0;9-0;10-0;</mapping>


### PR DESCRIPTION
Correct me if I am wrong, but I was debugging some issues syncing this multi-season TVDB to absolute numbered AniDB/Anilist series using Jellyfin Ani-Sync and I think this should use `defaulttvdbseason="a"` because of the mapping-list data. 
<!--
To make reviewing easier, please fill out the table with the IDs.
Detailing changes on the Notes column is appreciated:
E.g:
  Season 2
  Specials (2-5)
  Movie
  TVDB Removed \ Reordered Episodes

TVDB URLs are prefered in the example format (with ID) instead of their address bar redirect (title slug):
   👎 https://thetvdb.com/series/those-obnoxious-aliens/
   👍 https://thetvdb.com/index.php?tab=series&id=75113
-->

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/102 | https://thetvdb.com/index.php?tab=series&id=70668  | defaulttvdbseason="a" |

<!-- EXAMPLE ROWS - Enjoy CopyPaste
| https://anidb.net/anime/ | https://thetvdb.com/index.php?tab=series&id=70668 | Season X |
| https://anidb.net/anime/ | https://www.imdb.com/title/tt <br/> https://www.themoviedb.org/movie/ | Movie |
EXAMPLES END -->