### PR TITLE
Map Beastars Final Season (anidb:16443) to TVDB/TMDB

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -45499,7 +45499,7 @@
   <anime anidbid="16442" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbtv="" tmdbseason="" tmdboffset="" tmdbid="" imdbid="">
     <name>Gabuli</name>
   </anime>
-  <anime anidbid="16443" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbtv="" tmdbseason="" tmdboffset="" tmdbid="" imdbid="">
+  <anime anidbid="16443" tvdbid="361013" defaulttvdbseason="3" episodeoffset="" tmdbtv="90937" tmdbseason="3" tmdboffset="" tmdbid="" imdbid="">
     <name>Beastars Final Season</name>
   </anime>
   <anime anidbid="16444" tvdbid="" defaulttvdbseason="" episodeoffset="" tmdbtv="" tmdbseason="" tmdboffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
anidb:16443 (Beastars Final Season) had no TVDB/TMDB mapping.

| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/16443 | https://thetvdb.com/index.php?tab=series&id=361013 <br/> https://www.themoviedb.org/tv/90937 | Season 3 |
