### PR TITLE
Fix TVDB/TMDB for Yami no Matsuei and Hoshi no Koe

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -568,12 +568,8 @@
       <studio>Studio Pierrot</studio>
     </supplemental-info>
   </anime>
-  <anime anidbid="104" tvdbid="82023" defaulttvdbseason="1" episodeoffset="" tmdbtv="" tmdbseason="" tmdboffset="" tmdbid="" imdbid="tt0370754">
+  <anime anidbid="104" tvdbid="OVA" defaulttvdbseason="" episodeoffset="" tmdbtv="" tmdbseason="" tmdboffset="" tmdbid="37910" imdbid="tt0370754">
     <name>Hoshi no Koe</name>
-    <mapping-list>
-      <mapping anidbseason="0" tvdbseason="0" start="1" end="2" offset="1"/>
-      <mapping anidbseason="1" tvdbseason="0">;1-1;</mapping>
-    </mapping-list>
     <supplemental-info>
       <studio>CoMix Wave</studio>
     </supplemental-info>

--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -3152,7 +3152,7 @@
   <anime anidbid="749" tvdbid="83309" defaulttvdbseason="1" episodeoffset="" tmdbtv="45610" tmdbseason="1" tmdboffset="" tmdbid="" imdbid="">
     <name>Devilman Lady</name>
   </anime>
-  <anime anidbid="750" tvdbid="78855" defaulttvdbseason="1" episodeoffset="" tmdbtv="" tmdbseason="" tmdboffset="" tmdbid="" imdbid="">
+  <anime anidbid="750" tvdbid="82830" defaulttvdbseason="1" episodeoffset="" tmdbtv="12483" tmdbseason="1" tmdboffset="" tmdbid="" imdbid="">
     <name>Yami no Matsuei</name>
   </anime>
   <anime anidbid="751" tvdbid="72977" defaulttvdbseason="1" episodeoffset="" tmdbtv="20177" tmdbseason="1" tmdboffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
| AniDB | TVDB/TMDB/IMDB | Notes |
  | --- | --- | --- |
  | https://anidb.net/anime/750 | https://thetvdb.com/index.php?tab=series&id=82830 <br/> https://www.themoviedb.org/tv/12483 | Fix wrong TVDB id; add TMDB TV id |
  | https://anidb.net/anime/104 | https://www.themoviedb.org/movie/37910 | TVDB now lists as movie; reclassify as OVA, drop TVDB id, add TMDB id |
