### PR TITLE
Update TVDB ID for ANIDB 648 Uchuu Senkan Yamato

### DIFF
--- a/anime-list-master.xml
+++ b/anime-list-master.xml
@@ -2814,7 +2814,7 @@
   <anime anidbid="647" tvdbid="hentai" defaulttvdbseason="" episodeoffset="" tmdbtv="" tmdbseason="" tmdboffset="" tmdbid="" imdbid="">
     <name>MeiKing</name>
   </anime>
-  <anime anidbid="648" tvdbid="85230" defaulttvdbseason="1" episodeoffset="" tmdbtv="13339" tmdbseason="1" tmdboffset="" tmdbid="" imdbid="">
+  <anime anidbid="648" tvdbid="77773" defaulttvdbseason="1" episodeoffset="" tmdbtv="13339" tmdbseason="1" tmdboffset="" tmdbid="" imdbid="">
     <name>Uchuu Senkan Yamato</name>
   </anime>
   <anime anidbid="649" tvdbid="hentai" defaulttvdbseason="" episodeoffset="" tmdbtv="" tmdbseason="" tmdboffset="" tmdbid="" imdbid="">


### PR DESCRIPTION
| AniDB | TVDB/TMDB/IMDB | Notes |
| --- | --- | --- |
| https://anidb.net/anime/648| https://thetvdb.com/index.php?tab=series&id=77773 | Correct TVDB ID from 85230 (incorrect) to 77773 (correct) |